### PR TITLE
OU-547: Update ui plugins release branch for COO 1.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,19 +14,19 @@
 [submodule "ui-logging"]
 	path = ui-logging
 	url = https://github.com/openshift/logging-view-plugin.git
-	branch = main
+	branch = release-6.0
 [submodule "ui-dashboards"]
 	path = ui-dashboards
 	url = https://github.com/openshift/console-dashboards-plugin.git
-	branch = main
+	branch = release-0.3
 [submodule "ui-troubleshooting-panel"]
 	path = ui-troubleshooting-panel
 	url = https://github.com/openshift/troubleshooting-panel-console-plugin.git
-	branch = main
+	branch = release-0.3
 [submodule "ui-distributed-tracing"]
 	path = ui-distributed-tracing
 	url = https://github.com/openshift/distributed-tracing-console-plugin.git
-	branch = main
+	branch = release-0.3
 [submodule "ui-monitoring"]
 	path = ui-monitoring
 	url = https://github.com/openshift/monitoring-plugin.git


### PR DESCRIPTION
Update submodules to point to current release branch for each ui-plugin. All ui-plugins should point to `release-0.3` except for `ui-logging` which should be `release-0.6` and except for `ui-monitoring` which remains unchanged. 