### PR TITLE
reduce superfluous pipeline runs

### DIFF
--- a/.tekton/alertmanager-pull-request.yaml
+++ b/.tekton/alertmanager-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/alertmanager-pull-request.yaml".pathChanged() ||
+      ".tekton/alertmanager-push.yaml".pathChanged() ||
+      "Dockerfile.alertmanager".pathChanged() ||
+      "alertmanager".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/alertmanager-push.yaml
+++ b/.tekton/alertmanager-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/alertmanager-pull-request.yaml".pathChanged() ||
+      ".tekton/alertmanager-push.yaml".pathChanged() ||
+      "Dockerfile.alertmanager".pathChanged() ||
+      "alertmanager".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/cluster-observability-operator-bundle-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-bundle-pull-request.yaml
@@ -8,8 +8,12 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/cluster-observability-operator-bundle-pull-request.yaml".pathChanged() ||
+      ".tekton/cluster-observability-operator-bundle-push.yaml".pathChanged() ||
+      "Dockerfile.bundle".pathChanged() ||
+      "bundle-patches".pathChanged() ||
+      "observability-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/cluster-observability-operator-bundle-push.yaml
+++ b/.tekton/cluster-observability-operator-bundle-push.yaml
@@ -7,8 +7,12 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/cluster-observability-operator-bundle-pull-request.yaml".pathChanged() ||
+      ".tekton/cluster-observability-operator-bundle-push.yaml".pathChanged() ||
+      "Dockerfile.bundle".pathChanged() ||
+      "bundle-patches".pathChanged() ||
+      "observability-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/cluster-observability-operator-container-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-container-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/cluster-observability-operator-container-pull-request.yaml".pathChanged() ||
+      ".tekton/cluster-observability-operator-container-push.yaml".pathChanged() ||
+      "Dockerfile.obo".pathChanged() ||
+      "observability-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/cluster-observability-operator-container-push.yaml
+++ b/.tekton/cluster-observability-operator-container-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/cluster-observability-operator-container-pull-request.yaml".pathChanged() ||
+      ".tekton/cluster-observability-operator-container-push.yaml".pathChanged() ||
+      "Dockerfile.obo".pathChanged() ||
+      "observability-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/dashboards-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/dashboards-console-plugin-0-3-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/dashboards-console-plugin-0-3-pull-request.yaml".pathChanged() ||
+      ".tekton/dashboards-console-plugin-0-3-push.yaml".pathChanged() ||
+      "Dockerfile.ui-dashboards".pathChanged() ||
+      "ui-dashboards".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/dashboards-console-plugin-0-3-push.yaml
+++ b/.tekton/dashboards-console-plugin-0-3-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/dashboards-console-plugin-0-3-pull-request.yaml".pathChanged() ||
+      ".tekton/dashboards-console-plugin-0-3-push.yaml".pathChanged() ||
+      "Dockerfile.ui-dashboards".pathChanged() ||
+      "ui-dashboards".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/distributed-tracing-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/distributed-tracing-console-plugin-0-3-pull-request.yaml".pathChanged() ||
+      ".tekton/distributed-tracing-console-plugin-0-3-push.yaml".pathChanged() ||
+      "Dockerfile.ui-distributed-tracing".pathChanged() ||
+      "ui-distributed-tracing".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/distributed-tracing-console-plugin-0-3-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/distributed-tracing-console-plugin-0-3-pull-request.yaml".pathChanged() ||
+      ".tekton/distributed-tracing-console-plugin-0-3-push.yaml".pathChanged() ||
+      "Dockerfile.ui-distributed-tracing".pathChanged() ||
+      "ui-distributed-tracing".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/logging-console-plugin-6-0-pull-request.yaml
+++ b/.tekton/logging-console-plugin-6-0-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/logging-console-plugin-6-0-pull-request.yaml".pathChanged() ||
+      ".tekton/logging-console-plugin-6-0-push.yaml".pathChanged() ||
+      "Dockerfile.ui-logging".pathChanged() ||
+      "ui-logging".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/logging-console-plugin-6-0-push.yaml
+++ b/.tekton/logging-console-plugin-6-0-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/logging-console-plugin-6-0-pull-request.yaml".pathChanged() ||
+      ".tekton/logging-console-plugin-6-0-push.yaml".pathChanged() ||
+      "Dockerfile.ui-logging".pathChanged() ||
+      "ui-logging".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/monitoring-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-0-3-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/monitoring-console-plugin-0-3-pull-request.yaml".pathChanged() ||
+      ".tekton/monitoring-console-plugin-0-3-push.yaml".pathChanged() ||
+      "Dockerfile.ui-monitoring".pathChanged() ||
+      "ui-monitoring".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/monitoring-console-plugin-0-3-push.yaml
+++ b/.tekton/monitoring-console-plugin-0-3-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/monitoring-console-plugin-0-3-pull-request.yaml".pathChanged() ||
+      ".tekton/monitoring-console-plugin-0-3-push.yaml".pathChanged() ||
+      "Dockerfile.ui-monitoring".pathChanged() ||
+      "ui-monitoring".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/obo-prometheus-operator-admission-webhook-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/obo-prometheus-operator-admission-webhook-pull-request.yaml".pathChanged() ||
+      ".tekton/obo-prometheus-operator-admission-webhook-push.yaml".pathChanged() ||
+      "Dockerfile.p-o-admission-webhook".pathChanged() ||
+      "obo-prometheus-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/obo-prometheus-operator-admission-webhook-push.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/obo-prometheus-operator-admission-webhook-pull-request.yaml".pathChanged() ||
+      ".tekton/obo-prometheus-operator-admission-webhook-push.yaml".pathChanged() ||
+      "Dockerfile.p-o-admission-webhook".pathChanged() ||
+      "obo-prometheus-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/obo-prometheus-operator-prometheus-config-reloader-pull-request.yaml".pathChanged() ||
+      ".tekton/obo-prometheus-operator-prometheus-config-reloader-push.yaml".pathChanged() ||
+      "Dockerfile.prometheus-config-reloader".pathChanged() ||
+      "obo-prometheus-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-push.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/obo-prometheus-operator-prometheus-config-reloader-pull-request.yaml".pathChanged() ||
+      ".tekton/obo-prometheus-operator-prometheus-config-reloader-push.yaml".pathChanged() ||
+      "Dockerfile.prometheus-config-reloader".pathChanged() ||
+      "obo-prometheus-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/obo-prometheus-operator-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/obo-prometheus-operator-pull-request.yaml".pathChanged() ||
+      ".tekton/obo-prometheus-operator-push.yaml".pathChanged() ||
+      "Dockerfile.prom-op".pathChanged() ||
+      "obo-prometheus-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/obo-prometheus-operator-push.yaml
+++ b/.tekton/obo-prometheus-operator-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/obo-prometheus-operator-pull-request.yaml".pathChanged() ||
+      ".tekton/obo-prometheus-operator-push.yaml".pathChanged() ||
+      "Dockerfile.prom-op".pathChanged() ||
+      "obo-prometheus-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/prometheus-pull-request.yaml
+++ b/.tekton/prometheus-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/prometheus-pull-request.yaml".pathChanged() ||
+      ".tekton/prometheus-push.yaml".pathChanged() ||
+      "Dockerfile.prometheus".pathChanged() ||
+      "prometheus".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/prometheus-push.yaml
+++ b/.tekton/prometheus-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/prometheus-pull-request.yaml".pathChanged() ||
+      ".tekton/prometheus-push.yaml".pathChanged() ||
+      "Dockerfile.prometheus".pathChanged() ||
+      "prometheus".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/thanos-pull-request.yaml
+++ b/.tekton/thanos-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/thanos-pull-request.yaml".pathChanged() ||
+      ".tekton/thanos-push.yaml".pathChanged() ||
+      "Dockerfile.thanos".pathChanged() ||
+      "thanos".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/thanos-push.yaml
+++ b/.tekton/thanos-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/thanos-pull-request.yaml".pathChanged() ||
+      ".tekton/thanos-push.yaml".pathChanged() ||
+      "Dockerfile.thanos".pathChanged() ||
+      "thanos".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/troubleshooting-panel-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-3-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/troubleshooting-panel-console-plugin-0-3-pull-request.yaml".pathChanged() ||
+      ".tekton/troubleshooting-panel-console-plugin-0-3-push.yaml".pathChanged() ||
+      "Dockerfile.ui-troubleshooting-panel".pathChanged() ||
+      "ui-troubleshooting-panel".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0

--- a/.tekton/troubleshooting-panel-console-plugin-0-3-push.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-3-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/troubleshooting-panel-console-plugin-0-3-pull-request.yaml".pathChanged() ||
+      ".tekton/troubleshooting-panel-console-plugin-0-3-push.yaml".pathChanged() ||
+      "Dockerfile.ui-troubleshooting-panel".pathChanged() ||
+      "ui-troubleshooting-panel".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0


### PR DESCRIPTION
This adds constraints to the pipeline triggers to only run if relevant code paths have changed