### PR TITLE
COO-541: Set up source build image

### DIFF
--- a/.tekton/alertmanager-pull-request.yaml
+++ b/.tekton/alertmanager-pull-request.yaml
@@ -116,7 +116,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/alertmanager-push.yaml
+++ b/.tekton/alertmanager-push.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/cluster-observability-operator-bundle-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-bundle-pull-request.yaml
@@ -118,7 +118,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/cluster-observability-operator-bundle-push.yaml
+++ b/.tekton/cluster-observability-operator-bundle-push.yaml
@@ -115,7 +115,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/cluster-observability-operator-container-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-container-pull-request.yaml
@@ -116,7 +116,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/cluster-observability-operator-container-push.yaml
+++ b/.tekton/cluster-observability-operator-container-push.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/coo-fbc-v4-17-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-17-pull-request.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/coo-fbc-v4-17-push.yaml
+++ b/.tekton/coo-fbc-v4-17-push.yaml
@@ -110,7 +110,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/dashboards-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/dashboards-console-plugin-0-3-pull-request.yaml
@@ -116,7 +116,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/dashboards-console-plugin-0-3-push.yaml
+++ b/.tekton/dashboards-console-plugin-0-3-push.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/distributed-tracing-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-pull-request.yaml
@@ -116,7 +116,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/distributed-tracing-console-plugin-0-3-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-push.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/korrel8r-pull-request.yaml
+++ b/.tekton/korrel8r-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
       (".tekton/korrel8r-pull-request.yaml".pathChanged() ||
       ".tekton/korrel8r-push.yaml".pathChanged() ||
       "Dockerfile.korrel8r".pathChanged() ||
-      "korrel8r".pathChanged()) 
+      "korrel8r".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0
@@ -116,7 +116,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/korrel8r-push.yaml
+++ b/.tekton/korrel8r-push.yaml
@@ -10,7 +10,7 @@ metadata:
       (".tekton/korrel8r-pull-request.yaml".pathChanged() ||
       ".tekton/korrel8r-push.yaml".pathChanged() ||
       "Dockerfile.korrel8r".pathChanged() ||
-      "korrel8r".pathChanged()) 
+      "korrel8r".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-0
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/logging-console-plugin-6-0-pull-request.yaml
+++ b/.tekton/logging-console-plugin-6-0-pull-request.yaml
@@ -116,7 +116,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/logging-console-plugin-6-0-push.yaml
+++ b/.tekton/logging-console-plugin-6-0-push.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/monitoring-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-0-3-pull-request.yaml
@@ -116,7 +116,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/monitoring-console-plugin-0-3-push.yaml
+++ b/.tekton/monitoring-console-plugin-0-3-push.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/obo-prometheus-operator-admission-webhook-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-pull-request.yaml
@@ -116,7 +116,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/obo-prometheus-operator-admission-webhook-push.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-push.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-pull-request.yaml
@@ -116,7 +116,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-push.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-push.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/obo-prometheus-operator-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-pull-request.yaml
@@ -116,7 +116,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/obo-prometheus-operator-push.yaml
+++ b/.tekton/obo-prometheus-operator-push.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/prometheus-pull-request.yaml
+++ b/.tekton/prometheus-pull-request.yaml
@@ -116,7 +116,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/prometheus-push.yaml
+++ b/.tekton/prometheus-push.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/thanos-pull-request.yaml
+++ b/.tekton/thanos-pull-request.yaml
@@ -116,7 +116,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/thanos-push.yaml
+++ b/.tekton/thanos-push.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/troubleshooting-panel-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-3-pull-request.yaml
@@ -116,7 +116,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string

--- a/.tekton/troubleshooting-panel-console-plugin-0-3-push.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-3-push.yaml
@@ -113,7 +113,7 @@ spec:
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
-    - default: "false"
+    - default: "true"
       description: Build a source image.
       name: build-source-image
       type: string


### PR DESCRIPTION
Per the Red Hat policy, the build pipeline must be updated to build source images. In order to do so, we need to change the build-source-image parameter in both pipelines (push and pull-request) default value to "true"