### PR TITLE
Fix disallowed_inherited_labels for Thanos

### DIFF
--- a/Dockerfile.thanos
+++ b/Dockerfile.thanos
@@ -29,5 +29,6 @@ LABEL com.redhat.component="coo-thanos-container" \
       io.openshift.expose-services="" \
       io.openshift.tags="monitoring" \
       io.k8s.display-name="COO Thanos" \
+      io.k8s.description="Thanos extends Prometheus with highly available, scalable and unlimited metric storage." \
       maintainer="team-monitoring@redhat.com" \
       description="Thanos for Cluster Observability Operator"


### PR DESCRIPTION
This commit fixes the disallowed inherited tags violation for Thanos in COO.