### PR TITLE
Fix renovate json file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,6 @@
         "github>konflux-ci/mintmaker//config/renovate/renovate.json"
     ],
     "dockerfile": {
-        "fileMatch": ["^Dockerfile\.[a-zA-Z0-9\.-]+$"]
-    },
+        "fileMatch": ["^Dockerfile\\.[a-zA-Z0-9\\.-]+$"]
+    }
 }


### PR DESCRIPTION
The renovate.json file had an extra comma on it so it wasn't really being evaluated as a proper json.