### PR TITLE
Add console plugin description

### DIFF
--- a/Dockerfile.ui-logging
+++ b/Dockerfile.ui-logging
@@ -50,5 +50,6 @@ LABEL com.redhat.component="coo-logging-console-plugin" \
       summary="OpenShift console plugin to view and explore logs" \
       io.openshift.tags="openshift,observability-ui,logging" \
       io.k8s.display-name="OpenShift console logging plugin" \
+      io.k8s.description="OpenShift console plugin to view and explore logs" \
       maintainer="Observability UI Team <team-observability-ui@redhat.com>" \
       description="OpenShift console plugin to view and explore logs"


### PR DESCRIPTION
This commit fixes the disallowed inherited tags violation for Console Plugin in COO.
