### PR TITLE
Add distributed tracing description

### DIFF
--- a/Dockerfile.ui-distributed-tracing
+++ b/Dockerfile.ui-distributed-tracing
@@ -49,5 +49,6 @@ LABEL com.redhat.component="coo-distributed-tracing-console-plugin" \
       summary="OpenShift console plugin to view and explore traces" \
       io.openshift.tags="openshift,observability-ui,distributed tracing" \
       io.k8s.display-name="OpenShift console distributed tracing plugin" \
+      io.k8s.description="OpenShift console plugin to view and explore traces" \
       maintainer="Observability UI Team <team-observability-ui@redhat.com>" \
       description="OpenShift console plugin to view and explore traces"


### PR DESCRIPTION
This commit fixes the disallowed inherited tags violation for Distributed Tracing in COO.
