### PR TITLE
Enable multiarch builds for COO prometheus

### DIFF
--- a/.tekton/prometheus-pull-request.yaml
+++ b/.tekton/prometheus-pull-request.yaml
@@ -33,6 +33,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Dockerfile.prometheus
   - name: path-context

--- a/.tekton/prometheus-push.yaml
+++ b/.tekton/prometheus-push.yaml
@@ -30,6 +30,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Dockerfile.prometheus
   - name: path-context


### PR DESCRIPTION
This commit adds several architectures for the prometheus component of cluster-observability-operator.