### PR TITLE
Invoke promu directly in thanos builds

### DIFF
--- a/Dockerfile.thanos
+++ b/Dockerfile.thanos
@@ -11,7 +11,7 @@ ARG TARGETOS TARGETARCH
 RUN wget https://github.com/prometheus/promu/releases/download/v0.17.0/promu-0.17.0.${TARGETOS}-${TARGETARCH}.tar.gz \
     && tar -xzf promu-0.17.0.${TARGETOS}-${TARGETARCH}.tar.gz -C /usr/local/bin \
     && rm promu-0.17.0.${TARGETOS}-${TARGETARCH}.tar.gz \
-    && make build
+    && /usr/local/bin/promu-0.17.0.${TARGETOS}-${TARGETARCH}/promu -v build --prefix /go/bin/
 
 FROM registry.redhat.io/ubi8/ubi-minimal:8.10-1130
 WORKDIR /


### PR DESCRIPTION
This commit fixes an issue in s390x builds for thanos, where running the build Makefile target would hit an issue.