### PR TITLE
Add missing go mod env var in alertmanager

### DIFF
--- a/Dockerfile.alertmanager
+++ b/Dockerfile.alertmanager
@@ -3,6 +3,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.22
 RUN dnf module install -y nodejs:16/development
 
 ENV NPM_CONFIG_NODEDIR=/usr
+ENV GOFLAGS='-mod=mod'
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Without this var, the build defaults on vendoring and fails.