### PR TITLE
update the monitoring plugin build configuration to avoid conflicts with plugin installed from CMO

### DIFF
--- a/Dockerfile.ui-monitoring
+++ b/Dockerfile.ui-monitoring
@@ -10,6 +10,10 @@ COPY ui-monitoring/Makefile Makefile
 RUN make install-frontend-ci
 
 COPY ui-monitoring/web/ web/
+COPY ui-monitoring/config/ config/
+COPY ui-monitoring/scripts/update-plugin-name.sh scripts/update-plugin-name.sh
+RUN make update-plugin-name
+ENV I18N_NAMESPACE="plugin__monitoring-console-plugin"
 RUN make build-frontend
 
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as go-builder
@@ -39,6 +43,7 @@ USER 1001
 
 COPY --from=web-builder /opt/app-root/web/dist /opt/app-root/web/dist
 COPY --from=go-builder /opt/app-root/plugin-backend /opt/app-root
+COPY --from=web-builder /opt/app-root/config /opt/app-root/config
 
 ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist"]
 


### PR DESCRIPTION
This PR updates the monitoring plugin build configuration to avoid conflicts with plugin installed from CMO and updates the monitoring plugin to the latest main