### PR TITLE
Disable syft github-actions cataloger

### DIFF
--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,2 @@
+select-catalogers:
+  - -github-actions-usage-cataloger


### PR DESCRIPTION
This commit disables the syft github-actions cataloger, which has a bug breaking one of the pyxis steps in the Konflux release.