### PR TITLE
COO-571: bump prom-op to 0.78.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "obo-prometheus-operator"]
 	path = obo-prometheus-operator
 	url = https://github.com/rhobs/obo-prometheus-operator
-	branch = rhobs-rel-0.77.1-rhobs1
+	branch = rhobs-rel-0.78.1-rhobs1
 [submodule "observability-operator"]
 	path = observability-operator
 	url = https://github.com/rhobs/observability-operator


### PR DESCRIPTION
arm64 build is failing due a bug in prom-op version.

Update prom-op in order to fix it https://github.com/prometheus-operator/prometheus-operator/issues/7061