### PR TITLE
Fix gbc multiarch v17 push

### DIFF
--- a/.tekton/coo-fbc-v4-17-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-17-pull-request.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
@@ -7,8 +8,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-17-pull-request.yaml".pathChanged() ||
+      ".tekton/coo-fbc-v4-17-push.yaml".pathChanged() ||
+      "Dockerfile-4.17.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-17
@@ -85,7 +89,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "true"
+    - default: "false"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/.tekton/coo-fbc-v4-17-push.yaml
+++ b/.tekton/coo-fbc-v4-17-push.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
@@ -6,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-17-pull-request.yaml".pathChanged() ||
+      (".tekton/coo-fbc-v4-17-push.yaml".pathChanged() ||
+      "Dockerfile-4.17.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-17
@@ -53,28 +57,6 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-    - name: show-summary
-      params:
-      - name: pipelinerun-name
-        value: $(context.pipelineRun.name)
-      - name: git-url
-        value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
-      - name: image-url
-        value: $(params.output-image)
-      - name: build-task-status
-        value: $(tasks.build-image-index.status)
-      taskRef:
-        params:
-        - name: name
-          value: summary
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:870d9a04d9784840a90b7bf6817cd0d0c4edfcda04b1ba1868cae625a3c3bfcc
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-      - name: workspace
-        workspace: workspace
     params:
     - description: Source Repository URL
       name: git-url


### PR DESCRIPTION
This commit fixes a few settings that were missing for fbc push multiarch. It also sets the hermetic builds to false as a default and changes the fbc pipeline trigger.