### PR TITLE
COO-577: Disable cap on v4.17 pipeline trigger

### DIFF
--- a/.tekton/coo-fbc-v4-17-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-17-pull-request.yaml
@@ -8,11 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
-      (".tekton/coo-fbc-v4-17-pull-request.yaml".pathChanged() ||
-      ".tekton/coo-fbc-v4-17-push.yaml".pathChanged() ||
-      "Dockerfile-4.17.catalog".pathChanged() ||
-      "catalog/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-17

--- a/.tekton/coo-fbc-v4-17-push.yaml
+++ b/.tekton/coo-fbc-v4-17-push.yaml
@@ -7,11 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
-      (".tekton/coo-fbc-v4-17-pull-request.yaml".pathChanged() ||
-      (".tekton/coo-fbc-v4-17-push.yaml".pathChanged() ||
-      "Dockerfile-4.17.catalog".pathChanged() ||
-      "catalog/***".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-17


### PR DESCRIPTION
This commit disables the cap for pipeline triggering which was limiting it to edition on the catalog or the fbc Dockerfile.