### PR TITLE
Build fbc catalog only on change in pipelines.

### DIFF
--- a/.tekton/coo-fbc-v4-12-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-12-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-12-pull-request.yaml".pathChanged() ||
+      ".tekton/coo-fbc-v4-12-push.yaml".pathChanged() ||
+      "Dockerfile-4.12.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-12

--- a/.tekton/coo-fbc-v4-12-push.yaml
+++ b/.tekton/coo-fbc-v4-12-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-12-pull-request.yaml".pathChanged() ||
+      (".tekton/coo-fbc-v4-12-push.yaml".pathChanged() ||
+      "Dockerfile-4.12.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-12

--- a/.tekton/coo-fbc-v4-13-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-13-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-13-pull-request.yaml".pathChanged() ||
+      ".tekton/coo-fbc-v4-13-push.yaml".pathChanged() ||
+      "Dockerfile-4.13.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-13
@@ -201,7 +204,7 @@ spec:
         - name: PLATFORM
           value:
           - $(params.build-platforms)
-      name: build-images 
+      name: build-images
       params:
       - name: IMAGE
         value: $(params.output-image)

--- a/.tekton/coo-fbc-v4-13-push.yaml
+++ b/.tekton/coo-fbc-v4-13-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-13-pull-request.yaml".pathChanged() ||
+      (".tekton/coo-fbc-v4-13-push.yaml".pathChanged() ||
+      "Dockerfile-4.13.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-13
@@ -244,7 +247,7 @@ spec:
         value: $(params.build-image-index)
       - name: IMAGES
         value:
-        - $(tasks.build-images.results.IMAGE_REF[*]) 
+        - $(tasks.build-images.results.IMAGE_REF[*])
       runAfter:
       - build-images
       taskRef:

--- a/.tekton/coo-fbc-v4-14-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-14-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-14-pull-request.yaml".pathChanged() ||
+      ".tekton/coo-fbc-v4-14-push.yaml".pathChanged() ||
+      "Dockerfile-4.14.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-14
@@ -135,7 +138,7 @@ spec:
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
-      type: array 
+      type: array
     results:
     - description: ""
       name: IMAGE_URL
@@ -176,7 +179,7 @@ spec:
       - name: ociStorage
         value: $(params.output-image).git
       - name: ociArtifactExpiresAfter
-        value: $(params.image-expires-after) 
+        value: $(params.image-expires-after)
       runAfter:
       - init
       taskRef:
@@ -218,7 +221,7 @@ spec:
       - name: SOURCE_ARTIFACT
         value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
-        value: "true"  
+        value: "true"
       runAfter:
       - clone-repository
       taskRef:

--- a/.tekton/coo-fbc-v4-14-push.yaml
+++ b/.tekton/coo-fbc-v4-14-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-14-pull-request.yaml".pathChanged() ||
+      (".tekton/coo-fbc-v4-14-push.yaml".pathChanged() ||
+      "Dockerfile-4.14.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-14

--- a/.tekton/coo-fbc-v4-15-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-15-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-15-pull-request.yaml".pathChanged() ||
+      ".tekton/coo-fbc-v4-15-push.yaml".pathChanged() ||
+      "Dockerfile-4.15.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-15

--- a/.tekton/coo-fbc-v4-15-push.yaml
+++ b/.tekton/coo-fbc-v4-15-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-15-pull-request.yaml".pathChanged() ||
+      (".tekton/coo-fbc-v4-15-push.yaml".pathChanged() ||
+      "Dockerfile-4.15.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-15
@@ -223,7 +226,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:389e6691834144113987cd669a6b510e47d2cee55332b940eeb06ce24a9a57a2 
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:389e6691834144113987cd669a6b510e47d2cee55332b940eeb06ce24a9a57a2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/coo-fbc-v4-16-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-16-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-16-pull-request.yaml".pathChanged() ||
+      ".tekton/coo-fbc-v4-16-push.yaml".pathChanged() ||
+      "Dockerfile-4.16.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-16

--- a/.tekton/coo-fbc-v4-16-push.yaml
+++ b/.tekton/coo-fbc-v4-16-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-16-pull-request.yaml".pathChanged() ||
+      (".tekton/coo-fbc-v4-16-push.yaml".pathChanged() ||
+      "Dockerfile-4.16.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-16

--- a/.tekton/coo-fbc-v4-17-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-17-pull-request.yaml
@@ -8,7 +8,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-17-pull-request.yaml".pathChanged() ||
+      ".tekton/coo-fbc-v4-17-push.yaml".pathChanged() ||
+      "Dockerfile-4.17.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-17

--- a/.tekton/coo-fbc-v4-17-push.yaml
+++ b/.tekton/coo-fbc-v4-17-push.yaml
@@ -7,7 +7,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/coo-fbc-v4-17-pull-request.yaml".pathChanged() ||
+      (".tekton/coo-fbc-v4-17-push.yaml".pathChanged() ||
+      "Dockerfile-4.17.catalog".pathChanged() ||
+      "catalog/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: coo-fbc-v4-17


### PR DESCRIPTION
This commit modifies the trigger for the catalog build so it applies only when there's a change in the actual catalog in order to avoid having it rebuilt on every commit.

Note that this would mean stopping seeing this in every regular commit CI, but that wasn't a real update but a rebuilt.  Currently there's no automation in place to have the catalogs updated per commit in the CI.