### PR TITLE
Fix 4.15 fbc release

### DIFF
--- a/Dockerfile-4.15.catalog
+++ b/Dockerfile-4.15.catalog
@@ -1,5 +1,5 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.15.0
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.15
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]


### PR DESCRIPTION
This commit fixes the failure on the release's get_ocp_version task, which is getting an invalid parsing by the additional 0 on the Dockerfile.

Without this, it fails to parse the proper OCP version. The pattern does not match v4.15.0 because it expects a format like vX.Y