### PR TITLE
Fix 4.12 push tekton pipeline bad indentation

### DIFF
--- a/.tekton/coo-fbc-v4-12-push.yaml
+++ b/.tekton/coo-fbc-v4-12-push.yaml
@@ -35,7 +35,7 @@ spec:
       - linux/x86_64
       - linux/arm64
       - linux/ppc64le
-    pipelineSpec:
+  pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).
 


### PR DESCRIPTION
This commit fixes a bad indented 4_12 key issue on the 4_!2 push pipeline.