### PR TITLE
Ignore fbc catalog files in mintmaker

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,10 @@
     "extends": [
         "github>konflux-ci/mintmaker//config/renovate/renovate.json"
     ],
+    "ignoreDeps": [
+        "registry.redhat.io/openshift4/ose-operator-registry",
+        "registry.redhat.io/openshift4/ose-operator-registry-rhel9"
+    ],
     "dockerfile": {
         "fileMatch": ["^Dockerfile\\.[a-zA-Z0-9\\.-]+$"]
     }


### PR DESCRIPTION
This PR adds an exception to the registries which will update the fbc Dockerfiles, which is unwanted. Without this, fbc Dockerfile will receive PR trying to update them to newer versions of OpenShift.