### PR TITLE
Disable s390x and ppc64le build on tekton pr files

### DIFF
--- a/.tekton/alertmanager-pull-request.yaml
+++ b/.tekton/alertmanager-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.alertmanager
   - name: path-context

--- a/.tekton/cluster-observability-operator-container-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-container-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.obo
   - name: path-context

--- a/.tekton/coo-fbc-v4-12-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-12-pull-request.yaml
@@ -37,8 +37,6 @@ spec:
     value:
       - linux/x86_64
       - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).
@@ -133,8 +131,6 @@ spec:
     - default:
       - linux/x86_64
       - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms

--- a/.tekton/coo-fbc-v4-13-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-13-pull-request.yaml
@@ -37,8 +37,6 @@ spec:
     value:
       - linux/x86_64
       - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).
@@ -133,8 +131,6 @@ spec:
     - default:
       - linux/x86_64
       - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms

--- a/.tekton/coo-fbc-v4-14-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-14-pull-request.yaml
@@ -37,8 +37,6 @@ spec:
     value:
       - linux/x86_64
       - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).
@@ -133,8 +131,6 @@ spec:
     - default:
       - linux/x86_64
       - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms

--- a/.tekton/coo-fbc-v4-15-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-15-pull-request.yaml
@@ -37,8 +37,6 @@ spec:
     value:
       - linux/x86_64
       - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).
@@ -133,8 +131,6 @@ spec:
     - default:
       - linux/x86_64
       - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms

--- a/.tekton/coo-fbc-v4-16-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-16-pull-request.yaml
@@ -37,8 +37,6 @@ spec:
     value:
       - linux/x86_64
       - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).
@@ -133,8 +131,6 @@ spec:
     - default:
       - linux/x86_64
       - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms

--- a/.tekton/coo-fbc-v4-17-pull-request.yaml
+++ b/.tekton/coo-fbc-v4-17-pull-request.yaml
@@ -38,8 +38,6 @@ spec:
     value:
       - linux/x86_64
       - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).
@@ -112,8 +110,6 @@ spec:
     - default:
       - linux/x86_64
       - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms

--- a/.tekton/dashboards-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/dashboards-console-plugin-0-3-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.ui-dashboards
   - name: path-context

--- a/.tekton/distributed-tracing-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.ui-distributed-tracing
   - name: path-context

--- a/.tekton/korrel8r-pull-request.yaml
+++ b/.tekton/korrel8r-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.korrel8r
   - name: path-context

--- a/.tekton/logging-console-plugin-6-0-pull-request.yaml
+++ b/.tekton/logging-console-plugin-6-0-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.ui-logging
   - name: path-context

--- a/.tekton/monitoring-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-0-3-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.ui-monitoring
   - name: path-context

--- a/.tekton/obo-prometheus-operator-admission-webhook-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.p-o-admission-webhook
   - name: path-context

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.prometheus-config-reloader
   - name: path-context

--- a/.tekton/obo-prometheus-operator-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.prom-op
   - name: path-context

--- a/.tekton/prometheus-pull-request.yaml
+++ b/.tekton/prometheus-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.prometheus
   - name: path-context

--- a/.tekton/thanos-pull-request.yaml
+++ b/.tekton/thanos-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.thanos
   - name: path-context

--- a/.tekton/troubleshooting-panel-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-3-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.ui-troubleshooting-panel
   - name: path-context


### PR DESCRIPTION
This commit disables both s390x and ppc64le files in konflux-coo tekton pipelines in order for https://github.com/rhobs/konflux-coo/pull/413 to pass