### PR TITLE
Disable s390x and ppc64le in alertmanager pipeline

### DIFF
--- a/.tekton/alertmanager-pull-request.yaml
+++ b/.tekton/alertmanager-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.alertmanager
   - name: path-context


### PR DESCRIPTION
This commit disables s390x and ppc64le builds in
alertmanager-pull-request tekton pipeline.