### PR TITLE
Disable s390x and ppc64le in coo-container pipeline

### DIFF
--- a/.tekton/cluster-observability-operator-container-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-container-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.obo
   - name: path-context


### PR DESCRIPTION
This commit disables s390x and ppc64le builds in
cluster-observability-operator-pull-request tekton pipeline.