### PR TITLE
Disable s390x and ppc64le in dt

### DIFF
--- a/.tekton/distributed-tracing-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.ui-distributed-tracing
   - name: path-context


### PR DESCRIPTION
This commit disables s390x and ppc64le platforms in distributed tracing console plugin tekton pr.