### PR TITLE
Disable s390x and ppc64le in dashboards-console-plugin pipeline

### DIFF
--- a/.tekton/dashboards-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/dashboards-console-plugin-0-3-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.ui-dashboards
   - name: path-context


### PR DESCRIPTION
This commit disables s390x and ppc64le builds in
dashboards-console-plugin pull-request tekton pipeline.