### PR TITLE
Disable s390x and ppc64le in korrel8r pipeline

### DIFF
--- a/.tekton/korrel8r-pull-request.yaml
+++ b/.tekton/korrel8r-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.korrel8r
   - name: path-context


### PR DESCRIPTION
This commit disables s390x and ppc64le builds in
korrel8r pull-request tekton pipeline.