### PR TITLE
Disable s390x and ppc64le in logging-console-plugin pipeline

### DIFF
--- a/.tekton/logging-console-plugin-6-0-pull-request.yaml
+++ b/.tekton/logging-console-plugin-6-0-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.ui-logging
   - name: path-context


### PR DESCRIPTION
This commit disables s390x and ppc64le builds in
logging-console-plugin pull-request tekton pipeline.