### PR TITLE
Disable s390x and ppc64le in monitoring-console-plugin pipeline

### DIFF
--- a/.tekton/monitoring-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-0-3-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.ui-monitoring
   - name: path-context


### PR DESCRIPTION
This commit disables s390x and ppc64le builds in
monitoring-console-plugin pull-request tekton pipeline.