### PR TITLE
Disable s390x and ppc64le in obo admission webook pipeline

### DIFF
--- a/.tekton/obo-prometheus-operator-admission-webhook-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.p-o-admission-webhook
   - name: path-context


### PR DESCRIPTION
This commit disables s390x and ppc64le builds in
prom op admission webhook pull-request tekton pipeline.