### PR TITLE
Disable s390x and ppc64le in obo config reloader pipeline

### DIFF
--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.prometheus-config-reloader
   - name: path-context


### PR DESCRIPTION
This commit disables s390x and ppc64le builds in
prom op config reloader pull-request tekton pipeline.