### PR TITLE
Disable s390x and ppc64le in obo prom op pipeline

### DIFF
--- a/.tekton/obo-prometheus-operator-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.prom-op
   - name: path-context


### PR DESCRIPTION
This commit disables s390x and ppc64le builds in
prom op pull-request tekton pipeline.