### PR TITLE
Disable s390x and ppc64le in prometheus pipeline

### DIFF
--- a/.tekton/prometheus-pull-request.yaml
+++ b/.tekton/prometheus-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.prometheus
   - name: path-context


### PR DESCRIPTION
This commit disables s390x and ppc64le builds in
prometheus pull-request tekton pipeline.