### PR TITLE
Disable s390x and ppc64le in thanos pipeline

### DIFF
--- a/.tekton/thanos-pull-request.yaml
+++ b/.tekton/thanos-pull-request.yaml
@@ -34,8 +34,6 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.thanos
   - name: path-context


### PR DESCRIPTION
This commit disables s390x and ppc64le builds in
thanos pull-request tekton pipeline.