### PR TITLE
Format 4.18 fbc push yaml file

### DIFF
--- a/.tekton/coo-fbc-v4-18-push.yaml
+++ b/.tekton/coo-fbc-v4-18-push.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
@@ -26,16 +27,16 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/coo-fbc-v4-18:{{revision}}
+  - name: dockerfile
+    value: Dockerfile-4.18.catalog
+  - name: path-context
+    value: .
   - name: build-platforms
     value:
       - linux/x86_64
       - linux/arm64
       - linux/ppc64le
       - linux/s390x
-  - name: dockerfile
-    value: Dockerfile-4.18.catalog
-  - name: path-context
-    value: .
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).


### PR DESCRIPTION
This commit formats the coo-fbc-v4-18-push.yaml file in order to keep
the same style as the other ones.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>