### PR TITLE
fix: Use Pyxis image paths

### DIFF
--- a/bundle-patches/render_templates
+++ b/bundle-patches/render_templates
@@ -61,19 +61,19 @@ COO_CONSOLE_MONITORING_PLUGIN_IMAGE_URL="quay.io/redhat-user-workloads/cluster-o
 COO_KORREL8R_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/korrel8r@sha256:63a4cc85c064bfb32f7be06f598b1735881a644aa5ba5d65450dd050436cef98"
 
 if [[ $REGISTRY == "registry.redhat.io"  || $REGISTRY == "registry.stage.redhat.io" ]]; then
-    COO_IMAGE_URL="$REGISTRY/cluster-observability-operator/${COO_IMAGE_URL:58}"
-    COO_CONF_RELOADER_IMAGE_URL="$REGISTRY/cluster-observability-operator/${COO_CONF_RELOADER_IMAGE_URL:58}"
-    COO_ALERTMANAGER_IMAGE_URL="$REGISTRY/cluster-observability-operator/${COO_ALERTMANAGER_IMAGE_URL:58}"
-    COO_PROMETHEUS_IMAGE_URL="$REGISTRY/cluster-observability-operator/${COO_PROMETHEUS_IMAGE_URL:58}"
-    COO_THANOS_IMAGE_URL="$REGISTRY/cluster-observability-operator/${COO_THANOS_IMAGE_URL:58}"
-    COO_ADMISSION_WEBHOOK_IMAGE_URL="$REGISTRY/cluster-observability-operator/${COO_ADMISSION_WEBHOOK_IMAGE_URL:58}"
-    COO_PO_IMAGE_URL="$REGISTRY/cluster-observability-operator/${COO_PO_IMAGE_URL:58}"
-    COO_CONSOLE_DASHBOARDS_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/${COO_CONSOLE_DASHBOARDS_PLUGIN_IMAGE_URL:58}"
-    COO_CONSOLE_DISTRIBUTED_TRACING_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/${COO_CONSOLE_DISTRIBUTED_TRACING_PLUGIN_IMAGE_URL:58}"
-    COO_CONSOLE_LOGGING_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/${COO_CONSOLE_LOGGING_PLUGIN_IMAGE_URL:58}"
-    COO_CONSOLE_TROUBLESHOOTING_PANEL_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/${COO_CONSOLE_TROUBLESHOOTING_PANEL_PLUGIN_IMAGE_URL:58}"
-    COO_CONSOLE_MONITORING_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/${COO_CONSOLE_MONITORING_PLUGIN_IMAGE_URL:58}"
-    COO_KORREL8R_IMAGE_URL="$REGISTRY/cluster-observability-operator/${COO_KORREL8R_IMAGE_URL:58}"
+    COO_IMAGE_URL="$REGISTRY/cluster-observability-operator/cluster-observability-rhel8-operator@sha256:${COO_IMAGE_URL:(-64)}"
+    COO_CONF_RELOADER_IMAGE_URL="$REGISTRY/cluster-observability-operator/obo-prometheus-operator-prometheus-config-reloader-rhel8@sha256:${COO_CONF_RELOADER_IMAGE_URL:(-64)}"
+    COO_ALERTMANAGER_IMAGE_URL="$REGISTRY/cluster-observability-operator/alertmanager-rhel8@sha256:${COO_ALERTMANAGER_IMAGE_URL:(-64)}"
+    COO_PROMETHEUS_IMAGE_URL="$REGISTRY/cluster-observability-operator/prometheus-rhel8@sha256:${COO_PROMETHEUS_IMAGE_URL:(-64)}"
+    COO_THANOS_IMAGE_URL="$REGISTRY/cluster-observability-operator/thanos-rhel8@sha256:${COO_THANOS_IMAGE_URL:(-64)}"
+    COO_ADMISSION_WEBHOOK_IMAGE_URL="$REGISTRY/cluster-observability-operator/obo-prometheus-operator-admission-webhook-rhel8@sha256:${COO_ADMISSION_WEBHOOK_IMAGE_URL:(-64)}"
+    COO_PO_IMAGE_URL="$REGISTRY/cluster-observability-operator/obo-prometheus-rhel8-operator@sha256:${COO_PO_IMAGE_URL:(-64)}"
+    COO_CONSOLE_DASHBOARDS_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/dashboards-console-plugin-0-3-rhel9@sha256:${COO_CONSOLE_DASHBOARDS_PLUGIN_IMAGE_URL:(-64)}"
+    COO_CONSOLE_DISTRIBUTED_TRACING_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/distributed-tracing-console-plugin-0-3-rhel9@sha256:${COO_CONSOLE_DISTRIBUTED_TRACING_PLUGIN_IMAGE_URL:(-64)}"
+    COO_CONSOLE_LOGGING_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/logging-console-plugin-6-0-rhel9@sha256:${COO_CONSOLE_LOGGING_PLUGIN_IMAGE_URL:(-64)}"
+    COO_CONSOLE_TROUBLESHOOTING_PANEL_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/troubleshooting-panel-console-plugin-0-3-rhel9@sha256:${COO_CONSOLE_TROUBLESHOOTING_PANEL_PLUGIN_IMAGE_URL:(-64)}"
+    COO_CONSOLE_MONITORING_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/monitoring-console-plugin-0-3-rhel9@sha256:${COO_CONSOLE_MONITORING_PLUGIN_IMAGE_URL:(-64)}"
+    COO_KORREL8R_IMAGE_URL="$REGISTRY/cluster-observability-operator/korrel8r-rhel8@sha256:${COO_KORREL8R_IMAGE_URL:(-64)}"
 fi
 
 


### PR DESCRIPTION
Use the newer Pyxis image paths instead of Quay ones.

I've not made changes to the Quay paths that these images get pushed to, as that should eventually be irrelevant since customers will end up consuming from the production registry, while QE would use the staging one (and the fact that I want to keep the blast radius to a minimum). This is also in-line with what we have seen in [`rhosdt`](https://github.com/os-observability/konflux-tempo/blob/b85647809443699238765ce20e9b55131565023c/.tekton/tempo-opa-push.yaml#L37) as well.