### PR TITLE
Use proper registry for FBC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ generate-catalog: $(OPM)
 	$(OPM) alpha render-template basic --output yaml --migrate-level bundle-object-to-csv-metadata catalog/catalog-template.yaml > catalog/coo-product/catalog.yaml
 	# pre 4.17 the catalog should have bundle-object
 	$(OPM) alpha render-template basic --output yaml catalog/catalog-template.yaml > catalog/coo-product-4.16/catalog.yaml
+	# FBC repo issues shown here https://gitlab.cee.redhat.com/konflux/docs/users/-/merge_requests/189/diffs
+	sed -i 's|quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator-bundle|registry.redhat.io/cluster-observability-operator-bundle|g' catalog/coo-product/catalog.yaml
 
 .PHONY: lint
 lint: lint-pipelines

--- a/catalog/coo-product/catalog.yaml
+++ b/catalog/coo-product/catalog.yaml
@@ -15,7 +15,7 @@ name: stable
 package: cluster-observability-operator
 schema: olm.channel
 ---
-image: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator-bundle@sha256:6bbed33802a729e68cd4c7022536f83354c7c5d0b39773219786b5050c76b9ca
+image: registry.redhat.io/cluster-observability-operator-bundle@sha256:6bbed33802a729e68cd4c7022536f83354c7c5d0b39773219786b5050c76b9ca
 name: cluster-observability-operator.v1.0.0
 package: cluster-observability-operator
 properties:
@@ -282,7 +282,7 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator-bundle@sha256:6bbed33802a729e68cd4c7022536f83354c7c5d0b39773219786b5050c76b9ca
+- image: registry.redhat.io/cluster-observability-operator-bundle@sha256:6bbed33802a729e68cd4c7022536f83354c7c5d0b39773219786b5050c76b9ca
   name: ""
 - image: registry.redhat.io/cluster-observability-operator/alertmanager@sha256:62839a21d39e5f2fee397f84e1e37437d7d17c12018d6f87cf433a1856578e2b
   name: alertmanager


### PR DESCRIPTION
This PR modifies the pullspec in the catalog for the FBCs while also
introducing a modification on the make-generate Makefile target.

This ensures pullspec validity when running the opm command and
post-processes the catalog to update the pullspec later.

This will also make EC/Conforma validation fails, it's a known issue.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>