### PR TITLE
OU-453: Add perses-operator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,3 +42,7 @@
         path = korrel8r
         url = https://github.com/korrel8r/korrel8r.git
         branch = v0.7
+[submodule "perses-operator"]
+	path = perses-operator
+	url = https://github.com/perses/perses-operator
+	branch = release-coo-1.1

--- a/Dockerfile.perses-operator
+++ b/Dockerfile.perses-operator
@@ -1,0 +1,24 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.23 AS build-env
+
+USER root
+
+RUN dnf install -y mailcap && dnf clean all && rm -rf /var/cache/dnf
+
+WORKDIR /app
+
+COPY perses-operator/ .
+
+RUN make bin
+
+FROM registry.redhat.io/ubi8/ubi-minimal:8.10-1130
+
+LABEL maintainer="Observability UI team <team-observability-ui@redhat.com>"
+
+USER nobody
+
+COPY --from=build-env --chown=nobody:nobody /app/bin/manager  /bin/manager
+COPY --from=build-env --chown=nobody:nobody /app/LICENSE      /LICENSE
+COPY --from=build-env --chown=nobody:nobody /etc/mime.types   /etc/mime.types
+
+EXPOSE     8080
+ENTRYPOINT [ "/bin/manager" ]


### PR DESCRIPTION
## Related JIRA 
https://issues.redhat.com/browse/OU-453

## Description 
Add perses-operator as a component of the COO Konflux application. 

1.  Add perses-operator submodule and update `.gitmodule` to point at perses/perses-operator release branch `release-coo-1.1`

      -  Ran `$ git submodule add https://github.com/perses/perses-operator`

2. Add `Dockerfiler.perses-operator` for Konflux Pipeline to build the image 