### PR TITLE
Honor Pyxis naming conventions in Quay mirror

### DIFF
--- a/.tekton/alertmanager-pull-request.yaml
+++ b/.tekton/alertmanager-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/alertmanager:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/alertmanager-rhel8:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/alertmanager-push.yaml
+++ b/.tekton/alertmanager-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/alertmanager:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/alertmanager-rhel8:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/cluster-observability-operator-bundle-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-bundle-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator-bundle:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/cluster-observability-operator-bundle:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/cluster-observability-operator-bundle-push.yaml
+++ b/.tekton/cluster-observability-operator-bundle-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator-bundle:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/cluster-observability-operator-bundle:{{revision}}
   - name: dockerfile
     value: Dockerfile.bundle
   - name: path-context

--- a/.tekton/cluster-observability-operator-container-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-container-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator-container:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/cluster-observability-rhel8-operator:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/cluster-observability-operator-container-push.yaml
+++ b/.tekton/cluster-observability-operator-container-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator-container:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/cluster-observability-rhel8-operator:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/dashboards-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/dashboards-console-plugin-0-3-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/dashboards-console-plugin-0-3:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/dashboards-console-plugin-0-3-rhel9:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/dashboards-console-plugin-0-3-push.yaml
+++ b/.tekton/dashboards-console-plugin-0-3-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/dashboards-console-plugin-0-3:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/dashboards-console-plugin-0-3-rhel9:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/distributed-tracing-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/distributed-tracing-console-plugin-0-3:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/distributed-tracing-console-plugin-0-3-rhel9:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/distributed-tracing-console-plugin-0-3-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/distributed-tracing-console-plugin-0-3:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/distributed-tracing-console-plugin-0-3-rhel9:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/korrel8r-pull-request.yaml
+++ b/.tekton/korrel8r-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/korrel8r:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/korrel8r-rhel8:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/korrel8r-push.yaml
+++ b/.tekton/korrel8r-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/korrel8r:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/korrel8r-rhel8:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/logging-console-plugin-6-0-pull-request.yaml
+++ b/.tekton/logging-console-plugin-6-0-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/logging-console-plugin-6-0:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/logging-console-plugin-6-0-rhel9:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/logging-console-plugin-6-0-push.yaml
+++ b/.tekton/logging-console-plugin-6-0-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/logging-console-plugin-6-0:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/logging-console-plugin-6-0-rhel9:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/monitoring-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-0-3-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/monitoring-console-plugin-0-3:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/monitoring-console-plugin-0-3-rhel9:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/monitoring-console-plugin-0-3-push.yaml
+++ b/.tekton/monitoring-console-plugin-0-3-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/monitoring-console-plugin-0-3:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/monitoring-console-plugin-0-3-rhel9:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/obo-prometheus-operator-admission-webhook-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/obo-prometheus-operator-admission-webhook:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/obo-prometheus-rhel8-operator-admission-webhook:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/obo-prometheus-operator-admission-webhook-push.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/obo-prometheus-operator-admission-webhook:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/obo-prometheus-rhel8-operator-admission-webhook:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/obo-prometheus-operator-prometheus-config-reloader:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/obo-prometheus-rhel8-operator-prometheus-config-reloader:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-push.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/obo-prometheus-operator-prometheus-config-reloader:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/obo-prometheus-rhel8-operator-prometheus-config-reloader:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/obo-prometheus-operator-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/obo-prometheus-operator:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/obo-prometheus-rhel8-operator:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/obo-prometheus-operator-push.yaml
+++ b/.tekton/obo-prometheus-operator-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/obo-prometheus-operator:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/obo-prometheus-rhel8-operator:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/prometheus-pull-request.yaml
+++ b/.tekton/prometheus-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/prometheus:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/prometheus-rhel8:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/prometheus-push.yaml
+++ b/.tekton/prometheus-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/prometheus:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/prometheus-rhel8:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/thanos-pull-request.yaml
+++ b/.tekton/thanos-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/thanos:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/thanos-rhel8:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/thanos-push.yaml
+++ b/.tekton/thanos-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/thanos:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/thanos-rhel8:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/troubleshooting-panel-console-plugin-0-3-pull-request.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-3-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/troubleshooting-panel-console-plugin-0-3:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/troubleshooting-panel-console-plugin-0-3-rhel9:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/troubleshooting-panel-console-plugin-0-3-push.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-3-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/troubleshooting-panel-console-plugin-0-3:{{revision}}
+    value: quay.io/redhat-user-workloads/cluster-observability-operator/troubleshooting-panel-console-plugin-0-3-rhel9:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ generate-catalog: $(OPM)
 	# pre 4.17 the catalog should have bundle-object
 	$(OPM) alpha render-template basic --output yaml catalog/catalog-template.yaml > catalog/coo-product-4.16/catalog.yaml
 	# FBC repo issues shown here https://gitlab.cee.redhat.com/konflux/docs/users/-/merge_requests/189/diffs
-	sed -i 's|quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator-bundle|registry.redhat.io/cluster-observability-operator/cluster-observability-operator-bundle|g' catalog/coo-product/catalog.yaml
-	sed -i 's|quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator-bundle|registry.redhat.io/cluster-observability-operator/cluster-observability-operator-bundle|g' catalog/coo-product-4.16/catalog.yaml
+	sed -i 's|quay.io/redhat-user-workloads/cluster-observability-operator/cluster-observability-operator-bundle|registry.redhat.io/cluster-observability-operator/cluster-observability-operator-bundle|g' catalog/coo-product/catalog.yaml
+	sed -i 's|quay.io/redhat-user-workloads/cluster-observability-operator/cluster-observability-operator-bundle|registry.redhat.io/cluster-observability-operator/cluster-observability-operator-bundle|g' catalog/coo-product-4.16/catalog.yaml
 
 .PHONY: lint
 lint: lint-pipelines

--- a/bundle-patches/render_templates
+++ b/bundle-patches/render_templates
@@ -35,46 +35,46 @@ yq -i '.metadata.labels += {"operatorframework.io/arch.arm64": "supported"}' "$c
 yq -i '.metadata.labels += {"operatorframework.io/arch.ppc64le": "supported"}' "$csv_file"
 yq -i '.metadata.labels += {"operatorframework.io/arch.s390x": "supported"}' "$csv_file"
 
-COO_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator-container@sha256:3fec7abad7c547a9409d5a1f1098b82955b1d24aa3dae74017b75ada448eb6ef"
+COO_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observability-operator/cluster-observability-rhel8-operator@sha256:3fec7abad7c547a9409d5a1f1098b82955b1d24aa3dae74017b75ada448eb6ef"
 
-COO_CONF_RELOADER_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/obo-prometheus-operator-prometheus-config-reloader@sha256:e5d846203e6af0c7a432b325b2ea5f723bf0ba1bdca2a7bb2bd3a4cbed733afb"
+COO_CONF_RELOADER_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observability-operator/obo-prometheus-rhel8-operator-prometheus-config-reloader@sha256:e5d846203e6af0c7a432b325b2ea5f723bf0ba1bdca2a7bb2bd3a4cbed733afb"
 
-COO_ALERTMANAGER_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/alertmanager@sha256:3cefd74aa02afd9b79bd949c47091db30cf2e511e276170a9b92172c4cd51615"
+COO_ALERTMANAGER_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observability-operator/alertmanager-rhel8@sha256:3cefd74aa02afd9b79bd949c47091db30cf2e511e276170a9b92172c4cd51615"
 
-COO_PROMETHEUS_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/prometheus@sha256:7f76ffe32075465c09de363325b62d4b69def0306584c6d5b02ad9b74ae8bee4"
+COO_PROMETHEUS_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observability-operator/prometheus-rhel8@sha256:7f76ffe32075465c09de363325b62d4b69def0306584c6d5b02ad9b74ae8bee4"
 
-COO_THANOS_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/thanos@sha256:d1ca863ef7eac591783e64b2b26dbf90780805fac53551665b2b033034ca7990"
+COO_THANOS_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observability-operator/thanos-rhel8@sha256:d1ca863ef7eac591783e64b2b26dbf90780805fac53551665b2b033034ca7990"
 
-COO_ADMISSION_WEBHOOK_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/obo-prometheus-operator-admission-webhook@sha256:9351944d9a16c468b3dd65b5284ccfe107593e244d67eac2697d0bef32491915"
+COO_ADMISSION_WEBHOOK_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observability-operator/obo-prometheus-rhel8-operator-admission-webhook@sha256:9351944d9a16c468b3dd65b5284ccfe107593e244d67eac2697d0bef32491915"
 
-COO_PO_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/obo-prometheus-operator@sha256:0952abd9e73c8c1e81c555ad91f9197ece7981f30d93f909fdc69b900c05cbb6"
+COO_PO_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observability-operator/obo-prometheus-rhel8-operator@sha256:0952abd9e73c8c1e81c555ad91f9197ece7981f30d93f909fdc69b900c05cbb6"
 
-COO_CONSOLE_DASHBOARDS_PLUGIN_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/dashboards-console-plugin-0-3@sha256:5cadb12e90782c3a58e7543dfa8251da301ddb8035a4d216124e7cf2f0bc1dd5"
+COO_CONSOLE_DASHBOARDS_PLUGIN_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observability-operator/dashboards-console-plugin-0-3-rhel9@sha256:5cadb12e90782c3a58e7543dfa8251da301ddb8035a4d216124e7cf2f0bc1dd5"
 
-COO_CONSOLE_DISTRIBUTED_TRACING_PLUGIN_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/distributed-tracing-console-plugin-0-3@sha256:0ed9bf52447133dabf2f63df6f30e957e9d5481dc78603fadbc147454700e698"
+COO_CONSOLE_DISTRIBUTED_TRACING_PLUGIN_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observability-operator/distributed-tracing-console-plugin-0-3-rhel9@sha256:0ed9bf52447133dabf2f63df6f30e957e9d5481dc78603fadbc147454700e698"
 
-COO_CONSOLE_LOGGING_PLUGIN_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/logging-console-plugin-6-0@sha256:c93a476caca5e8edf9ad5c4d34221f0c915c3ca42e8d50b69a9cc676d0007546"
+COO_CONSOLE_LOGGING_PLUGIN_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observability-operator/logging-console-plugin-6-0-rhel9@sha256:c93a476caca5e8edf9ad5c4d34221f0c915c3ca42e8d50b69a9cc676d0007546"
 
-COO_CONSOLE_TROUBLESHOOTING_PANEL_PLUGIN_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/troubleshooting-panel-console-plugin-0-3@sha256:64061474ffe7831e55cb021f859bbf8ce2cd6455b3ce92a0b539ef0129b6ec8f"
+COO_CONSOLE_TROUBLESHOOTING_PANEL_PLUGIN_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observability-operator/troubleshooting-panel-console-plugin-0-3-rhel9@sha256:64061474ffe7831e55cb021f859bbf8ce2cd6455b3ce92a0b539ef0129b6ec8f"
 
-COO_CONSOLE_MONITORING_PLUGIN_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/monitoring-console-plugin-0-3@sha256:1f1ba1ddc18df5e638078493e6f3610d65797271d0ca8a083499236f48a7628b"
+COO_CONSOLE_MONITORING_PLUGIN_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observability-operator/monitoring-console-plugin-0-3-rhel9@sha256:1f1ba1ddc18df5e638078493e6f3610d65797271d0ca8a083499236f48a7628b"
 
-COO_KORREL8R_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/korrel8r@sha256:20d107770d7584bfed99aa5168e450681d3fdd265fe0dff272b80741196e64ee"
+COO_KORREL8R_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observability-operator/korrel8r-rhel8@sha256:20d107770d7584bfed99aa5168e450681d3fdd265fe0dff272b80741196e64ee"
 
 if [[ $REGISTRY == "registry.redhat.io"  || $REGISTRY == "registry.stage.redhat.io" ]]; then
-    COO_IMAGE_URL="$REGISTRY/cluster-observability-operator/cluster-observability-rhel8-operator@sha256:${COO_IMAGE_URL:(-64)}"
-    COO_CONF_RELOADER_IMAGE_URL="$REGISTRY/cluster-observability-operator/obo-prometheus-operator-prometheus-config-reloader-rhel8@sha256:${COO_CONF_RELOADER_IMAGE_URL:(-64)}"
-    COO_ALERTMANAGER_IMAGE_URL="$REGISTRY/cluster-observability-operator/alertmanager-rhel8@sha256:${COO_ALERTMANAGER_IMAGE_URL:(-64)}"
-    COO_PROMETHEUS_IMAGE_URL="$REGISTRY/cluster-observability-operator/prometheus-rhel8@sha256:${COO_PROMETHEUS_IMAGE_URL:(-64)}"
-    COO_THANOS_IMAGE_URL="$REGISTRY/cluster-observability-operator/thanos-rhel8@sha256:${COO_THANOS_IMAGE_URL:(-64)}"
-    COO_ADMISSION_WEBHOOK_IMAGE_URL="$REGISTRY/cluster-observability-operator/obo-prometheus-operator-admission-webhook-rhel8@sha256:${COO_ADMISSION_WEBHOOK_IMAGE_URL:(-64)}"
-    COO_PO_IMAGE_URL="$REGISTRY/cluster-observability-operator/obo-prometheus-rhel8-operator@sha256:${COO_PO_IMAGE_URL:(-64)}"
-    COO_CONSOLE_DASHBOARDS_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/dashboards-console-plugin-0-3-rhel9@sha256:${COO_CONSOLE_DASHBOARDS_PLUGIN_IMAGE_URL:(-64)}"
-    COO_CONSOLE_DISTRIBUTED_TRACING_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/distributed-tracing-console-plugin-0-3-rhel9@sha256:${COO_CONSOLE_DISTRIBUTED_TRACING_PLUGIN_IMAGE_URL:(-64)}"
-    COO_CONSOLE_LOGGING_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/logging-console-plugin-6-0-rhel9@sha256:${COO_CONSOLE_LOGGING_PLUGIN_IMAGE_URL:(-64)}"
-    COO_CONSOLE_TROUBLESHOOTING_PANEL_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/troubleshooting-panel-console-plugin-0-3-rhel9@sha256:${COO_CONSOLE_TROUBLESHOOTING_PANEL_PLUGIN_IMAGE_URL:(-64)}"
-    COO_CONSOLE_MONITORING_PLUGIN_IMAGE_URL="$REGISTRY/cluster-observability-operator/monitoring-console-plugin-0-3-rhel9@sha256:${COO_CONSOLE_MONITORING_PLUGIN_IMAGE_URL:(-64)}"
-    COO_KORREL8R_IMAGE_URL="$REGISTRY/cluster-observability-operator/korrel8r-rhel8@sha256:${COO_KORREL8R_IMAGE_URL:(-64)}"
+    COO_IMAGE_URL="$REGISTRY/${COO_IMAGE_URL:30}"
+    COO_CONF_RELOADER_IMAGE_URL="$REGISTRY/${COO_CONF_RELOADER_IMAGE_URL:30}"
+    COO_ALERTMANAGER_IMAGE_URL="$REGISTRY/${COO_ALERTMANAGER_IMAGE_URL:30}"
+    COO_PROMETHEUS_IMAGE_URL="$REGISTRY/${COO_PROMETHEUS_IMAGE_URL:30}"
+    COO_THANOS_IMAGE_URL="$REGISTRY/${COO_THANOS_IMAGE_URL:30}"
+    COO_ADMISSION_WEBHOOK_IMAGE_URL="$REGISTRY/${COO_ADMISSION_WEBHOOK_IMAGE_URL:30}"
+    COO_PO_IMAGE_URL="$REGISTRY/${COO_PO_IMAGE_URL:30}"
+    COO_CONSOLE_DASHBOARDS_PLUGIN_IMAGE_URL="$REGISTRY/${COO_CONSOLE_DASHBOARDS_PLUGIN_IMAGE_URL:30}"
+    COO_CONSOLE_DISTRIBUTED_TRACING_PLUGIN_IMAGE_URL="$REGISTRY/${COO_CONSOLE_DISTRIBUTED_TRACING_PLUGIN_IMAGE_URL:30}"
+    COO_CONSOLE_LOGGING_PLUGIN_IMAGE_URL="$REGISTRY/${COO_CONSOLE_LOGGING_PLUGIN_IMAGE_URL:30}"
+    COO_CONSOLE_TROUBLESHOOTING_PANEL_PLUGIN_IMAGE_URL="$REGISTRY/${COO_CONSOLE_TROUBLESHOOTING_PANEL_PLUGIN_IMAGE_URL:30}"
+    COO_CONSOLE_MONITORING_PLUGIN_IMAGE_URL="$REGISTRY/${COO_CONSOLE_MONITORING_PLUGIN_IMAGE_URL:30}"
+    COO_KORREL8R_IMAGE_URL="$REGISTRY/${COO_KORREL8R_IMAGE_URL:30}"
 fi
 
 

--- a/catalog/catalog-template.yaml
+++ b/catalog/catalog-template.yaml
@@ -16,6 +16,6 @@ entries:
   name: stable
   package: cluster-observability-operator
   schema: olm.channel
-- image: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator-bundle@sha256:221e3514c869644f63e03c58467648cfc2a241de976941e29f1ae4492d2d6e0a
+- image: quay.io/redhat-user-workloads/cluster-observability-operator/cluster-observability-operator-bundle@sha256:221e3514c869644f63e03c58467648cfc2a241de976941e29f1ae4492d2d6e0a
   schema: olm.bundle
 schema: olm.template.basic


### PR DESCRIPTION
My assumption here is that changing the `output-image` parameter used in the Tekton specifications for building components should allow us to technically specify our own namespace as long as the prefix is `quay.io/redhat-user-workloads`, instead of `quay.io/redhat-user-workloads/cluster-observabilit-tenant`, based on the observation that various tasks defined in the same manifest refer to the OCI storage path derived from this parameter. However, if this is not the case, I'll just change the repository names for Quay to align with the latter.