### PR TITLE
DNM: Enable COO thanos hermetic builds

### DIFF
--- a/.tekton/thanos-1-1-pull-request.yaml
+++ b/.tekton/thanos-1-1-pull-request.yaml
@@ -44,6 +44,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./thanos"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/thanos-1-1-push.yaml
+++ b/.tekton/thanos-1-1-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./thanos"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
This commit enables hermetic builds in COO Thanos push and pull
pipelines. Do not merge this for now as this is contingent on promu
being present.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>
