### PR TITLE
feat: Add hermetic builds for logging-view-plugin-6-1 in COO 1.1

### DIFF
--- a/.tekton/logging-console-plugin-6-1-1-1-pull-request.yaml
+++ b/.tekton/logging-console-plugin-6-1-1-1-pull-request.yaml
@@ -42,6 +42,10 @@ spec:
       value: Dockerfile.ui-logging
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "."}, {"type": "npm", "path":"./web"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/logging-console-plugin-6-1-1-1-push.yaml
+++ b/.tekton/logging-console-plugin-6-1-1-1-push.yaml
@@ -39,6 +39,10 @@ spec:
       value: Dockerfile.ui-logging
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "."}, {"type": "npm", "path":"./web"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:


### PR DESCRIPTION
Related to the PR below which adds --ignore-script to `make install-frontend-ci`

https://github.com/openshift/logging-view-plugin/pull/262