### PR TITLE
Add RHOCP repo

### DIFF
--- a/.tekton/thanos-1-1-push.yaml
+++ b/.tekton/thanos-1-1-push.yaml
@@ -92,6 +92,10 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
+      - default: "true"
+        description: Enable dev-package-managers in prefetch task
+        name: prefetch-dev-package-managers-enabled
+        type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
@@ -190,6 +194,8 @@ spec:
             value: $(params.output-image).prefetch
           - name: ociArtifactExpiresAfter
             value: $(params.image-expires-after)
+          - name: dev-package-managers
+            value: $(params.prefetch-dev-package-managers-enabled)
         runAfter:
           - clone-repository
         taskRef:


### PR DESCRIPTION
This commit adds the initial repo file for promu.
This also adds the default, set to false for now as an example in the
thanos pipeline.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>