### PR TITLE
Enable dev-package-managers for promu

### DIFF
--- a/.tekton/prometheus-1-1-pull-request.yaml
+++ b/.tekton/prometheus-1-1-pull-request.yaml
@@ -95,6 +95,10 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
+      - default: "true"
+        description: Enable dev-package-managers in prefetch task
+        name: prefetch-dev-package-managers-enabled
+        type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
@@ -193,6 +197,8 @@ spec:
             value: $(params.output-image).prefetch
           - name: ociArtifactExpiresAfter
             value: $(params.image-expires-after)
+          - name: dev-package-managers
+            value: $(params.prefetch-dev-package-managers-enabled)
         runAfter:
           - clone-repository
         taskRef:

--- a/.tekton/prometheus-1-1-push.yaml
+++ b/.tekton/prometheus-1-1-push.yaml
@@ -92,6 +92,10 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
+      - default: "true"
+        description: Enable dev-package-managers in prefetch task
+        name: prefetch-dev-package-managers-enabled
+        type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
@@ -190,6 +194,8 @@ spec:
             value: $(params.output-image).prefetch
           - name: ociArtifactExpiresAfter
             value: $(params.image-expires-after)
+          - name: dev-package-managers
+            value: $(params.prefetch-dev-package-managers-enabled)
         runAfter:
           - clone-repository
         taskRef:

--- a/.tekton/thanos-1-1-pull-request.yaml
+++ b/.tekton/thanos-1-1-pull-request.yaml
@@ -95,6 +95,10 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
+      - default: "true"
+        description: Enable dev-package-managers in prefetch task
+        name: prefetch-dev-package-managers-enabled
+        type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
@@ -193,6 +197,8 @@ spec:
             value: $(params.output-image).prefetch
           - name: ociArtifactExpiresAfter
             value: $(params.image-expires-after)
+          - name: dev-package-managers
+            value: $(params.prefetch-dev-package-managers-enabled)
         runAfter:
           - clone-repository
         taskRef:

--- a/.tekton/thanos-1-1-push.yaml
+++ b/.tekton/thanos-1-1-push.yaml
@@ -92,6 +92,10 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
+      - default: "true"
+        description: Enable dev-package-managers in prefetch task
+        name: prefetch-dev-package-managers-enabled
+        type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
@@ -190,6 +194,8 @@ spec:
             value: $(params.output-image).prefetch
           - name: ociArtifactExpiresAfter
             value: $(params.image-expires-after)
+          - name: dev-package-managers
+            value: $(params.prefetch-dev-package-managers-enabled)
         runAfter:
           - clone-repository
         taskRef:


### PR DESCRIPTION
This commit enables dev-package-managers for promu in prefetch task for
components that would install promu for their build. This is necessary
for enabling rpm prefetch builds.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>