### PR TITLE
Add bundle version to task-rpms-signature-scan

### DIFF
--- a/.tekton/alertmanager-1-1-pull-request.yaml
+++ b/.tekton/alertmanager-1-1-pull-request.yaml
@@ -591,7 +591,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/alertmanager-1-1-push.yaml
+++ b/.tekton/alertmanager-1-1-push.yaml
@@ -588,7 +588,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/cluster-health-analyzer-0-4-1-1-pull-request.yaml
+++ b/.tekton/cluster-health-analyzer-0-4-1-1-pull-request.yaml
@@ -591,7 +591,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/cluster-health-analyzer-0-4-1-1-push.yaml
+++ b/.tekton/cluster-health-analyzer-0-4-1-1-push.yaml
@@ -588,7 +588,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/cluster-observability-operator-1-1-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-1-1-pull-request.yaml
@@ -591,7 +591,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/cluster-observability-operator-1-1-push.yaml
+++ b/.tekton/cluster-observability-operator-1-1-push.yaml
@@ -588,7 +588,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/cluster-observability-operator-bundle-1-1-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-bundle-1-1-pull-request.yaml
@@ -589,7 +589,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cluster-observability-operator-bundle-1-1-push.yaml
+++ b/.tekton/cluster-observability-operator-bundle-1-1-push.yaml
@@ -586,7 +586,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/dashboards-console-plugin-0-4-1-1-pull-request.yaml
+++ b/.tekton/dashboards-console-plugin-0-4-1-1-pull-request.yaml
@@ -591,7 +591,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/dashboards-console-plugin-0-4-1-1-push.yaml
+++ b/.tekton/dashboards-console-plugin-0-4-1-1-push.yaml
@@ -588,7 +588,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/distributed-tracing-console-plugin-0-4-1-1-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-4-1-1-pull-request.yaml
@@ -591,7 +591,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/distributed-tracing-console-plugin-0-4-1-1-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-4-1-1-push.yaml
@@ -588,7 +588,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/korrel8r-1-1-pull-request.yaml
+++ b/.tekton/korrel8r-1-1-pull-request.yaml
@@ -591,7 +591,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/korrel8r-1-1-push.yaml
+++ b/.tekton/korrel8r-1-1-push.yaml
@@ -588,7 +588,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/logging-console-plugin-6-1-1-1-pull-request.yaml
+++ b/.tekton/logging-console-plugin-6-1-1-1-pull-request.yaml
@@ -595,7 +595,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/logging-console-plugin-6-1-1-1-push.yaml
+++ b/.tekton/logging-console-plugin-6-1-1-1-push.yaml
@@ -592,7 +592,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/monitoring-console-plugin-0-4-1-1-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-0-4-1-1-pull-request.yaml
@@ -591,7 +591,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/monitoring-console-plugin-0-4-1-1-push.yaml
+++ b/.tekton/monitoring-console-plugin-0-4-1-1-push.yaml
@@ -588,7 +588,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/obo-prometheus-operator-1-1-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-1-1-pull-request.yaml
@@ -591,7 +591,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/obo-prometheus-operator-1-1-push.yaml
+++ b/.tekton/obo-prometheus-operator-1-1-push.yaml
@@ -588,7 +588,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-1-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-1-pull-request.yaml
@@ -591,7 +591,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-1-push.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-1-push.yaml
@@ -588,7 +588,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-1-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-1-pull-request.yaml
@@ -591,7 +591,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-1-push.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-1-push.yaml
@@ -588,7 +588,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/prometheus-1-1-pull-request.yaml
+++ b/.tekton/prometheus-1-1-pull-request.yaml
@@ -597,7 +597,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/prometheus-1-1-push.yaml
+++ b/.tekton/prometheus-1-1-push.yaml
@@ -594,7 +594,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/thanos-1-1-pull-request.yaml
+++ b/.tekton/thanos-1-1-pull-request.yaml
@@ -597,7 +597,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/thanos-1-1-push.yaml
+++ b/.tekton/thanos-1-1-push.yaml
@@ -594,7 +594,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/troubleshooting-panel-console-plugin-0-4-1-1-pull-request.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-4-1-1-pull-request.yaml
@@ -591,7 +591,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/troubleshooting-panel-console-plugin-0-4-1-1-push.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-4-1-1-push.yaml
@@ -588,7 +588,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
Even though it's valid, the EC policy needs it to match the correct
bundle and not failing on untrusted task.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>