### PR TITLE
feat: enable hermetic builds for uiplugins, perses, and  perses-operator

### DIFF
--- a/.tekton/dashboards-console-plugin-0-4-1-1-pull-request.yaml
+++ b/.tekton/dashboards-console-plugin-0-4-1-1-pull-request.yaml
@@ -42,6 +42,10 @@ spec:
       value: Dockerfile.ui-dashboards
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-dashboards"}, {"type": "npm", "path":"./ui-dashboards/web"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/dashboards-console-plugin-0-4-1-1-push.yaml
+++ b/.tekton/dashboards-console-plugin-0-4-1-1-push.yaml
@@ -39,6 +39,10 @@ spec:
       value: Dockerfile.ui-dashboards
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-dashboards"}, {"type": "npm", "path":"./ui-dashboards/web"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/distributed-tracing-console-plugin-0-3-1-1-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-1-1-pull-request.yaml
@@ -42,6 +42,10 @@ spec:
       value: Dockerfile.ui-distributed-tracing-pf4
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-distributed-tracing-pf4"}, {"type": "npm", "path":"./ui-distributed-tracing-pf4/web"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/distributed-tracing-console-plugin-0-3-1-1-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-1-1-push.yaml
@@ -39,6 +39,10 @@ spec:
       value: Dockerfile.ui-distributed-tracing-pf4
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-distributed-tracing-pf4"}, {"type": "npm", "path":"./ui-distributed-tracing-pf4/web"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/distributed-tracing-console-plugin-0-4-1-1-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-4-1-1-pull-request.yaml
@@ -42,6 +42,10 @@ spec:
       value: Dockerfile.ui-distributed-tracing
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-distributed-tracing"}, {"type": "npm", "path":"./ui-distributed-tracing/web"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/distributed-tracing-console-plugin-0-4-1-1-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-4-1-1-push.yaml
@@ -39,6 +39,10 @@ spec:
       value: Dockerfile.ui-distributed-tracing
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-distributed-tracing"}, {"type": "npm", "path":"./ui-distributed-tracing/web"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/logging-console-plugin-6-0-1-1-pull-request.yaml
+++ b/.tekton/logging-console-plugin-6-0-1-1-pull-request.yaml
@@ -42,6 +42,10 @@ spec:
       value: Dockerfile.ui-logging-pf4
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-logging-pf4"}, {"type": "npm", "path":"./ui-logging-pf4/web"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/logging-console-plugin-6-0-1-1-push.yaml
+++ b/.tekton/logging-console-plugin-6-0-1-1-push.yaml
@@ -39,6 +39,10 @@ spec:
       value: Dockerfile.ui-logging-pf4
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-logging-pf4"}, {"type": "npm", "path":"./ui-logging-pf4/web"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/perses-0-50-1-1-pull-request.yaml
+++ b/.tekton/perses-0-50-1-1-pull-request.yaml
@@ -42,6 +42,10 @@ spec:
       value: Dockerfile.perses
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./perses"}, {"type": "npm", "path":"./perses/ui"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/perses-0-50-1-1-push.yaml
+++ b/.tekton/perses-0-50-1-1-push.yaml
@@ -39,6 +39,10 @@ spec:
       value: Dockerfile.perses
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./perses"}, {"type": "npm", "path":"./perses/ui"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/perses-operator-0-1-1-1-pull-request.yaml
+++ b/.tekton/perses-operator-0-1-1-1-pull-request.yaml
@@ -42,6 +42,8 @@ spec:
       value: Dockerfile.perses-operator
     - name: path-context
       value: .
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./perses-operator"}'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/perses-operator-0-1-1-1-push.yaml
+++ b/.tekton/perses-operator-0-1-1-1-push.yaml
@@ -39,6 +39,10 @@ spec:
       value: Dockerfile.perses-operator
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./perses-operator"}'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/troubleshooting-panel-console-plugin-0-4-1-1-pull-request.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-4-1-1-pull-request.yaml
@@ -42,6 +42,10 @@ spec:
       value: Dockerfile.ui-troubleshooting-panel
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-troubleshooting-panel"}, {"type": "npm", "path":"./ui-troubleshooting-panel/web"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/troubleshooting-panel-console-plugin-0-4-1-1-push.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-4-1-1-push.yaml
@@ -39,6 +39,10 @@ spec:
       value: Dockerfile.ui-troubleshooting-panel
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-troubleshooting-panel"}, {"type": "npm", "path":"./ui-troubleshooting-panel/web"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:


### PR DESCRIPTION
## Description
Enable hermetic builds: 
1. ui-logging-pf4 (logging-view-plugin v6.0, supports Patternfly4)  
    - prefetch: go.mod, npm 
2. ui-logging (logging-view-plugin v6.1, supports Patternfly5) 
    - prefetch: go.mod, npm 
3. ui-dashboards 
    - prefetch: go.mod, npm 
4. ui-troubleshooting-panel
   - prefetch: go.mod, npm 
5. ui-distributed-tracing-pf4 (logging-view-plugin v0.3, supports Patternfly4) 
    - prefetch: go.mod, npm 
6. ui-distributed-tracing (logging-view-plugin v0.4, supports Patternfly5) 
     - prefetch: go.mod, npm 
7. perses 
     - prefetch: go.mod, npm 
8. perses-operator 
    - prefetch: go.mod, (*does not have frontend component, no need to prefetch for npm )

### Context
"A hermetic build is a secure, self-contained build process that doesn’t depend on anything outside of the build environment. This means that it does not have network access, is not vulnerable to external influences, and cannot fetch dependencies at run time. Instead, you must declare all required resources and dependencies in your build definition.

In Konflux, you can block network access to the build process and run a hermetic build by setting the hermetic parameter in your pipeline definition file to true. This means that you must fetch all dependencies before the build can start. " 
https://konflux.pages.redhat.com/docs/users/how-tos/configuring/hermetic-builds.html (VPN required)