### PR TITLE
Enable hermetic builds for Thanos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "alertmanager"]
 	path = alertmanager
 	url = https://github.com/prometheus/alertmanager
-        branch = release-0.28
+    branch = release-0.28
 [submodule "prometheus"]
 	path = prometheus
 	url = https://github.com/prometheus/prometheus.git
-        branch = release-3.2
+    branch = release-3.2
 [submodule "obo-prometheus-operator"]
 	path = obo-prometheus-operator
 	url = https://github.com/rhobs/obo-prometheus-operator
@@ -37,11 +37,11 @@
 [submodule "thanos"]
 	path = thanos
 	url = https://github.com/openshift/thanos.git
-        branch = release-4.18
+    branch = release-4.18
 [submodule "korrel8r"]
-        path = korrel8r
-        url = https://github.com/korrel8r/korrel8r.git
-        branch = v0.8
+    path = korrel8r
+    url = https://github.com/korrel8r/korrel8r.git
+    branch = v0.8
 [submodule "perses-operator"]
 	path = perses-operator
 	url = https://github.com/perses/perses-operator

--- a/.tekton/thanos-1-1-pull-request.yaml
+++ b/.tekton/thanos-1-1-pull-request.yaml
@@ -28,6 +28,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./thanos"}]'
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/thanos-rhel8:on-pr-{{revision}}
     - name: image-expires-after
@@ -94,10 +98,6 @@ spec:
       - default: "false"
         description: Execute the build with network isolation
         name: hermetic
-        type: string
-      - default: "true"
-        description: Enable dev-package-managers in prefetch task
-        name: prefetch-dev-package-managers-enabled
         type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
@@ -197,8 +197,6 @@ spec:
             value: $(params.output-image).prefetch
           - name: ociArtifactExpiresAfter
             value: $(params.image-expires-after)
-          - name: dev-package-managers
-            value: $(params.prefetch-dev-package-managers-enabled)
         runAfter:
           - clone-repository
         taskRef:

--- a/.tekton/thanos-1-1-push.yaml
+++ b/.tekton/thanos-1-1-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./thanos"}]'
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/thanos-rhel8:{{revision}}
     - name: build-platforms
@@ -91,10 +95,6 @@ spec:
       - default: "false"
         description: Execute the build with network isolation
         name: hermetic
-        type: string
-      - default: "true"
-        description: Enable dev-package-managers in prefetch task
-        name: prefetch-dev-package-managers-enabled
         type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
@@ -194,8 +194,6 @@ spec:
             value: $(params.output-image).prefetch
           - name: ociArtifactExpiresAfter
             value: $(params.image-expires-after)
-          - name: dev-package-managers
-            value: $(params.prefetch-dev-package-managers-enabled)
         runAfter:
           - clone-repository
         taskRef:

--- a/Dockerfile.thanos
+++ b/Dockerfile.thanos
@@ -4,21 +4,18 @@ WORKDIR /workspace
 
 COPY thanos .
 
-ENV GOFLAGS='-mod=mod'
+ENV GOFLAGS='-mod=mod -a'
 ENV CGO_ENABLED=0
 
-# Install promu and build thanos
+# Build Thanos directly using Go
 ARG TARGETOS TARGETARCH
-RUN wget https://github.com/prometheus/promu/releases/download/v0.17.0/promu-0.17.0.${TARGETOS}-${TARGETARCH}.tar.gz \
-    && tar -xzf promu-0.17.0.${TARGETOS}-${TARGETARCH}.tar.gz -C /usr/local/bin \
-    && rm promu-0.17.0.${TARGETOS}-${TARGETARCH}.tar.gz \
-    && /usr/local/bin/promu-0.17.0.${TARGETOS}-${TARGETARCH}/promu -v build --prefix /go/bin/
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags -netgo $GOFLAGS -o /go/bin/thanos ./cmd/thanos
 
 FROM registry.redhat.io/ubi8/ubi-minimal:8.10-1130
 WORKDIR /
 
 COPY --from=builder /go/bin/thanos /bin/thanos
-COPY --from=builder /workspace/LICENSE      /licenses/.
+COPY --from=builder /workspace/LICENSE /licenses/.
 
 USER nobody
 ENTRYPOINT [ "/bin/thanos" ]


### PR DESCRIPTION
This commit enables hermetic builds for Thanos. It also modifies its
Dockerfile to skip using promu and removes the rpm fetcher configuration
given that COO is in the public cluster and can't access internal RH
network.

This is dependent on https://github.com/openshift/thanos/pull/159.
Otherwise this would fail to find the golang toolchain.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>
