### PR TITLE
fix: Fix perses-operator prefetch-input value

### DIFF
--- a/.tekton/perses-operator-0-1-1-1-pull-request.yaml
+++ b/.tekton/perses-operator-0-1-1-1-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
     - name: path-context
       value: .
     - name: prefetch-input
-      value: '[{"type": "gomod", "path": "./perses-operator"}'
+      value: '[{"type": "gomod", "path": "./perses-operator"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/perses-operator-0-1-1-1-push.yaml
+++ b/.tekton/perses-operator-0-1-1-1-push.yaml
@@ -42,7 +42,7 @@ spec:
     - name: hermetic
       value: "true"
     - name: prefetch-input
-      value: '[{"type": "gomod", "path": "./perses-operator"}'
+      value: '[{"type": "gomod", "path": "./perses-operator"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:


### PR DESCRIPTION
Before
      `value: '[{"type": "gomod", "path": "./perses-operator"}'`

After 
      `value: '[{"type": "gomod", "path": "./perses-operator"}]'`
* missed the closing square bracket `]`