### PR TITLE
Enable rpm lockfile for perses operator

### DIFF
--- a/.tekton/perses-operator-0-1-1-1-pull-request.yaml
+++ b/.tekton/perses-operator-0-1-1-1-pull-request.yaml
@@ -13,6 +13,7 @@ metadata:
               (".tekton/.tekton/perses-operator-0-1-1-1-pull-request.yaml".pathChanged() ||
               ".tekton/.tekton/perses-operator-0-1-1-1-push.yaml".pathChanged() ||
               "Dockerfile.perses-operator".pathChanged() ||
+              "rpms.lock.yaml".pathChanged() ||
               "perses-operator".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
@@ -42,8 +43,12 @@ spec:
       value: Dockerfile.perses-operator
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
     - name: prefetch-input
-      value: '[{"type": "gomod", "path": "./perses-operator"}]'
+      value: '[{"type": "gomod", "path": "./perses-operator"}, {"type":  "rpm"}]'
+    - name: prefetch-dev-package-managers-enabled
+      value: "true"
     - name: build-source-image
       value: "true"
   pipelineSpec:
@@ -96,6 +101,10 @@ spec:
       - default: "false"
         description: Execute the build with network isolation
         name: hermetic
+        type: string
+      - default: "false"
+        description: Enable dev-package-managers in prefetch task
+        name: prefetch-dev-package-managers-enabled
         type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
@@ -195,6 +204,8 @@ spec:
             value: $(params.output-image).prefetch
           - name: ociArtifactExpiresAfter
             value: $(params.image-expires-after)
+          - name: dev-package-managers
+            value: $(params.prefetch-dev-package-managers-enabled)
         runAfter:
           - clone-repository
         taskRef:
@@ -593,7 +604,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/perses-operator-0-1-1-1-push.yaml
+++ b/.tekton/perses-operator-0-1-1-1-push.yaml
@@ -12,6 +12,7 @@ metadata:
               (".tekton/.tekton/perses-operator-0-1-1-1-pull-request.yaml".pathChanged() ||
               ".tekton/.tekton/perses-operator-0-1-1-1-push.yaml".pathChanged() ||
               "Dockerfile.perses-operator".pathChanged() ||
+              "rpms.lock.yaml".pathChanged() ||
               "perses-operator".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
@@ -42,7 +43,9 @@ spec:
     - name: hermetic
       value: "true"
     - name: prefetch-input
-      value: '[{"type": "gomod", "path": "./perses-operator"}]'
+      value: '[{"type": "gomod", "path": "./perses-operator"}, {"type": "rpm"}]'
+    - name: prefetch-dev-package-managers-enabled
+      value: "true"
     - name: build-source-image
       value: "true"
   pipelineSpec:
@@ -95,6 +98,10 @@ spec:
       - default: "false"
         description: Execute the build with network isolation
         name: hermetic
+        type: string
+      - default: "false"
+        description: Enable dev-package-managers in prefetch task
+        name: prefetch-dev-package-managers-enabled
         type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
@@ -194,6 +201,8 @@ spec:
             value: $(params.output-image).prefetch
           - name: ociArtifactExpiresAfter
             value: $(params.image-expires-after)
+          - name: dev-package-managers
+            value: $(params.prefetch-dev-package-managers-enabled)
         runAfter:
           - clone-repository
         taskRef:
@@ -592,7 +601,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/Dockerfile.perses-operator
+++ b/Dockerfile.perses-operator
@@ -2,7 +2,9 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.23
 
 USER root
 
-RUN dnf install -y mailcap && dnf clean all && rm -rf /var/cache/dnf
+RUN dnf install -y --setopt=tsflags=nodocs mailcap && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 WORKDIR /app
 

--- a/rhocp.repo
+++ b/rhocp.repo
@@ -1,6 +1,0 @@
-[rhocp-4.18-for-rhel-9-rpms]
-nane = rhocp 4.18 repo
-baseurl = https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.18/os/
-enabled = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-gpgcheck = 1

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -1,8 +1,8 @@
 contentOrigin:
   repofiles:
-    - rhocp.repo
+    - ubi8.repo
 packages:
-  - golang-github-prometheus-promu
+  - mailcap
 arches:
   - x86_64
   - aarch64

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -4,45 +4,45 @@ lockfileVendor: redhat
 arches:
 - arch: aarch64
   packages:
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.18/os/Packages/g/golang-github-prometheus-promu-0.16.0-20.gitf6c51c9.el9.aarch64.rpm
-    repoid: rhocp-4.18-for-rhel-9-rpms
-    size: 2474075
-    checksum: sha256:88a4cf2402a8a53b4a8c9c14b87c2aeb58840578eb643e32f717237450eefaa4
-    name: golang-github-prometheus-promu
-    evr: 0.16.0-20.gitf6c51c9.el9
-    sourcerpm: golang-github-prometheus-promu-0.16.0-20.gitf6c51c9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/m/mailcap-2.1.48-3.el8.noarch.rpm
+    repoid: ubi-8-baseos-rpms
+    size: 39708
+    checksum: sha256:b2d5f3c4e187dc8c6f94b551fc021925188ab7675e02a317111aa0b49965f03e
+    name: mailcap
+    evr: 2.1.48-3.el8
+    sourcerpm: mailcap-2.1.48-3.el8.src.rpm
   source: []
   module_metadata: []
 - arch: ppc64le
   packages:
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.18/os/Packages/g/golang-github-prometheus-promu-0.16.0-20.gitf6c51c9.el9.ppc64le.rpm
-    repoid: rhocp-4.18-for-rhel-9-rpms
-    size: 2453797
-    checksum: sha256:49bba9f50980dccbe74a59a5328cde541ede7653d1bcd4bdd9d006f761ab569f
-    name: golang-github-prometheus-promu
-    evr: 0.16.0-20.gitf6c51c9.el9
-    sourcerpm: golang-github-prometheus-promu-0.16.0-20.gitf6c51c9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/m/mailcap-2.1.48-3.el8.noarch.rpm
+    repoid: ubi-8-baseos-rpms
+    size: 39708
+    checksum: sha256:b2d5f3c4e187dc8c6f94b551fc021925188ab7675e02a317111aa0b49965f03e
+    name: mailcap
+    evr: 2.1.48-3.el8
+    sourcerpm: mailcap-2.1.48-3.el8.src.rpm
   source: []
   module_metadata: []
 - arch: s390x
   packages:
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.18/os/Packages/g/golang-github-prometheus-promu-0.16.0-20.gitf6c51c9.el9.s390x.rpm
-    repoid: rhocp-4.18-for-rhel-9-rpms
-    size: 2582051
-    checksum: sha256:d306329f6be0ffb96df9290cc6ce56dfc38110c319ca1d556b1b0f9aa102148a
-    name: golang-github-prometheus-promu
-    evr: 0.16.0-20.gitf6c51c9.el9
-    sourcerpm: golang-github-prometheus-promu-0.16.0-20.gitf6c51c9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/m/mailcap-2.1.48-3.el8.noarch.rpm
+    repoid: ubi-8-baseos-rpms
+    size: 39708
+    checksum: sha256:b2d5f3c4e187dc8c6f94b551fc021925188ab7675e02a317111aa0b49965f03e
+    name: mailcap
+    evr: 2.1.48-3.el8
+    sourcerpm: mailcap-2.1.48-3.el8.src.rpm
   source: []
   module_metadata: []
 - arch: x86_64
   packages:
-  - url: https://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.18/os/Packages/g/golang-github-prometheus-promu-0.16.0-20.gitf6c51c9.el9.x86_64.rpm
-    repoid: rhocp-4.18-for-rhel-9-rpms
-    size: 2756145
-    checksum: sha256:653a70ca32bbc38790a8c2eeed427fbaa15c4a10716d929f60aa72c64b041fa1
-    name: golang-github-prometheus-promu
-    evr: 0.16.0-20.gitf6c51c9.el9
-    sourcerpm: golang-github-prometheus-promu-0.16.0-20.gitf6c51c9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/m/mailcap-2.1.48-3.el8.noarch.rpm
+    repoid: ubi-8-baseos-rpms
+    size: 39708
+    checksum: sha256:b2d5f3c4e187dc8c6f94b551fc021925188ab7675e02a317111aa0b49965f03e
+    name: mailcap
+    evr: 2.1.48-3.el8
+    sourcerpm: mailcap-2.1.48-3.el8.src.rpm
   source: []
   module_metadata: []

--- a/ubi8.repo
+++ b/ubi8.repo
@@ -1,0 +1,70 @@
+[ubi-8-baseos-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-baseos-debug-rpms]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-baseos-source]
+name = Red Hat Universal Base Image 8 (Source RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-appstream-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-appstream-debug-rpms]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-appstream-source]
+name = Red Hat Universal Base Image 8 (Source RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-codeready-builder-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-codeready-builder]
+name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/os
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+
+[ubi-8-codeready-builder-debug-rpms]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-codeready-builder-source]
+name = Red Hat Universal Base Image 8 (Source RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1


### PR DESCRIPTION
This commit adds the ubi8 rpm repo for perses operator hermetic builds
and enables the dev-preview package manager for rpm prefetching.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>
