### PR TITLE
Use Konflux supported RPM repo identifiers

### DIFF
--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -5,44 +5,68 @@ arches:
 - arch: aarch64
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/m/mailcap-2.1.48-3.el8.noarch.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 39708
     checksum: sha256:b2d5f3c4e187dc8c6f94b551fc021925188ab7675e02a317111aa0b49965f03e
     name: mailcap
     evr: 2.1.48-3.el8
     sourcerpm: mailcap-2.1.48-3.el8.src.rpm
-  source: []
+  source:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/source/SRPMS/Packages/m/mailcap-2.1.48-3.el8.src.rpm
+    repoid: ubi-8-for-aarch64-baseos-source-rpms
+    size: 41545
+    checksum: sha256:69f964011d33e14100bf07212c9268ba5b61f2237c5bd6da1498b43c3789d91c
+    name: mailcap
+    evr: 2.1.48-3.el8
   module_metadata: []
 - arch: ppc64le
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/m/mailcap-2.1.48-3.el8.noarch.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 39708
     checksum: sha256:b2d5f3c4e187dc8c6f94b551fc021925188ab7675e02a317111aa0b49965f03e
     name: mailcap
     evr: 2.1.48-3.el8
     sourcerpm: mailcap-2.1.48-3.el8.src.rpm
-  source: []
+  source:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/source/SRPMS/Packages/m/mailcap-2.1.48-3.el8.src.rpm
+    repoid: ubi-8-for-ppc64le-baseos-source-rpms
+    size: 41545
+    checksum: sha256:69f964011d33e14100bf07212c9268ba5b61f2237c5bd6da1498b43c3789d91c
+    name: mailcap
+    evr: 2.1.48-3.el8
   module_metadata: []
 - arch: s390x
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/m/mailcap-2.1.48-3.el8.noarch.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 39708
     checksum: sha256:b2d5f3c4e187dc8c6f94b551fc021925188ab7675e02a317111aa0b49965f03e
     name: mailcap
     evr: 2.1.48-3.el8
     sourcerpm: mailcap-2.1.48-3.el8.src.rpm
-  source: []
+  source:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/source/SRPMS/Packages/m/mailcap-2.1.48-3.el8.src.rpm
+    repoid: ubi-8-for-s390x-baseos-source-rpms
+    size: 41545
+    checksum: sha256:69f964011d33e14100bf07212c9268ba5b61f2237c5bd6da1498b43c3789d91c
+    name: mailcap
+    evr: 2.1.48-3.el8
   module_metadata: []
 - arch: x86_64
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/m/mailcap-2.1.48-3.el8.noarch.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 39708
     checksum: sha256:b2d5f3c4e187dc8c6f94b551fc021925188ab7675e02a317111aa0b49965f03e
     name: mailcap
     evr: 2.1.48-3.el8
     sourcerpm: mailcap-2.1.48-3.el8.src.rpm
-  source: []
+  source:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/source/SRPMS/Packages/m/mailcap-2.1.48-3.el8.src.rpm
+    repoid: ubi-8-for-x86_64-baseos-source-rpms
+    size: 41545
+    checksum: sha256:69f964011d33e14100bf07212c9268ba5b61f2237c5bd6da1498b43c3789d91c
+    name: mailcap
+    evr: 2.1.48-3.el8
   module_metadata: []

--- a/ubi8.repo
+++ b/ubi8.repo
@@ -1,70 +1,62 @@
-[ubi-8-baseos-rpms]
+[ubi-8-for-$basearch-baseos-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-baseos-debug-rpms]
+[ubi-8-for-$basearch-baseos-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-baseos-source]
+[ubi-8-for-$basearch-baseos-source-rpms]
 name = Red Hat Universal Base Image 8 (Source RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/source/SRPMS
-enabled = 0
+enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-appstream-rpms]
+[ubi-8-for-$basearch-appstream-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-appstream-debug-rpms]
+[ubi-8-for-$basearch-appstream-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-appstream-source]
+[ubi-8-for-$basearch-appstream-source-rpms]
 name = Red Hat Universal Base Image 8 (Source RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/source/SRPMS
-enabled = 0
+enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-codeready-builder-rpms]
+[codeready-builder-for-ubi-8-$basearch-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-codeready-builder]
-name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/os
-enabled = 0
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-gpgcheck = 1
-
-
-[ubi-8-codeready-builder-debug-rpms]
+[codeready-builder-for-ubi-8-$basearch-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-codeready-builder-source]
+[codeready-builder-for-ubi-8-$basearch-source-rpms]
 name = Red Hat Universal Base Image 8 (Source RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/source/SRPMS
-enabled = 0
+enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1


### PR DESCRIPTION
This commit updates the rpm lockfile so the repo ids match what's
expected in Konflux repository identifiers [1]. It also enables source
repositories for the needed packages.

[1] https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/known_rpm_repositories.yml

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>
