### PR TITLE
COO-679: korrel8r: user hermetic builds

### DIFF
--- a/.tekton/korrel8r-1-1-pull-request.yaml
+++ b/.tekton/korrel8r-1-1-pull-request.yaml
@@ -42,6 +42,10 @@ spec:
       value: Dockerfile.korrel8r
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./korrel8r"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:

--- a/.tekton/korrel8r-1-1-push.yaml
+++ b/.tekton/korrel8r-1-1-push.yaml
@@ -39,6 +39,10 @@ spec:
       value: Dockerfile.korrel8r
     - name: path-context
       value: .
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./korrel8r"}]'
     - name: build-source-image
       value: "true"
   pipelineSpec:


### PR DESCRIPTION
This commit adds hermetic builds to korrel8r tekton pipelines in
konflux.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>