### PR TITLE
ci: add verify-render-templates.sh

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -9,3 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: make --always-make lint
+  verify:
+    name: Run verification steps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make --always-make verify

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-## Tools
+.PHONY: all
+all: verify lint
+
+.PHONY: verify
+verify:
+	./hack/verify-render-templates.sh
+
 .PHONY: lint
 lint: lint-pipelines
 

--- a/hack/verify-render-templates.sh
+++ b/hack/verify-render-templates.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+for f in .tekton/*push*; do
+    image=$(yq '.spec.params[] | select(.name =="output-image").value' "$f")
+    image="${image:0:(-13)}"
+    if ! grep "$image" bundle-patches/render_templates > /dev/null; then
+        # the bundle image can be skipped
+        if [[ ${image:(-6)} != "bundle" ]]; then
+            echo "$image is missing from render_templates"
+            exit 1
+        fi
+    fi
+    done


### PR DESCRIPTION
This currently extracks all output-images from pipelines and check whether the image is mentioned in `render_templates`. The bundle is skipped.