### PR TITLE
Add missing bundle version to task-rpms-signature-scan

### DIFF
--- a/.tekton/distributed-tracing-console-plugin-0-3-1-1-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-1-1-pull-request.yaml
@@ -595,7 +595,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/distributed-tracing-console-plugin-0-3-1-1-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-1-1-push.yaml
@@ -592,7 +592,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/logging-console-plugin-6-0-1-1-pull-request.yaml
+++ b/.tekton/logging-console-plugin-6-0-1-1-pull-request.yaml
@@ -595,7 +595,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/logging-console-plugin-6-0-1-1-push.yaml
+++ b/.tekton/logging-console-plugin-6-0-1-1-push.yaml
@@ -592,7 +592,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:b9cb1e126d186010e0a5281501b475177d55b4eb2829c5e7d7614c173a8c929c
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
Some components are missing the 0.2 version for the task-rpms-signature-scan bundle. See rhobs#744