### PR TITLE
fix Perses backend and Perses operator submodule source branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,11 +45,11 @@
 [submodule "perses-operator"]
 	path = perses-operator
 	url = https://github.com/perses/perses-operator
-	branch = release-coo-1.1
+	branch = release/v0.1
 [submodule "perses"]
 	path = perses
 	url = https://github.com/perses/perses.git
-	branch = release-0.50.1
+	branch = release/v0.50
 [submodule "cluster-health-analyzer"]
 	path = cluster-health-analyzer
 	url = https://github.com/openshift/cluster-health-analyzer


### PR DESCRIPTION
Not sure if there is a configuration elsewhere that keeps pointing renovate to the wrong branches, any idea @jan--f ?