### PR TITLE
renovate: update only default repo branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,8 @@
     ],
     "dockerfile": {
         "fileMatch": ["^Dockerfile\\.[a-zA-Z0-9\\.-]+$"]
+    },
+    {
+      "baseBranches": ["$default"]
     }
 }


### PR DESCRIPTION
Enfornce renovate to use only default repo branch when getting PR
updates from it. [1]

[1] https://docs.renovatebot.com/configuration-options/#basebranches

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>