### PR TITLE
add nudge-file to bundle pipelines

### DIFF
--- a/.tekton/cluster-observability-operator-bundle-1-1-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-bundle-1-1-pull-request.yaml
@@ -14,6 +14,7 @@ metadata:
       "Dockerfile.bundle".pathChanged() ||
       "bundle-patches/***".pathChanged() ||
       "observability-operator".pathChanged())
+    build.appstudio.openshift.io/build-nudge-files: hack/update-catalog.sh
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-1

--- a/.tekton/cluster-observability-operator-bundle-1-1-push.yaml
+++ b/.tekton/cluster-observability-operator-bundle-1-1-push.yaml
@@ -13,6 +13,7 @@ metadata:
       "Dockerfile.bundle".pathChanged() ||
       "bundle-patches/***".pathChanged() ||
       "observability-operator".pathChanged())
+    build.appstudio.openshift.io/build-nudge-files: hack/update-catalog.sh
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-1


### PR DESCRIPTION
The bundle nudges the catalog. For an orderly update the nudge should only update the script that updates the catalog template. See https://github.com/rhobs/konflux-coo-fbc/pull/51