### PR TITLE
Configure hermetic builds

### DIFF
--- a/.tekton/cluster-observability-operator-1-2-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-1-2-pull-request.yaml
@@ -44,6 +44,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./observability-operator"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/cluster-observability-operator-1-2-push.yaml
+++ b/.tekton/cluster-observability-operator-1-2-push.yaml
@@ -13,6 +13,7 @@ metadata:
               ".tekton/cluster-observability-operator-1-2-push.yaml".pathChanged() ||
               "Dockerfile.obo".pathChanged() ||
               "observability-operator/***".pathChanged())
+    build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2
@@ -40,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./observability-operator"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/dashboards-console-plugin-0-4-1-2-pull-request.yaml
+++ b/.tekton/dashboards-console-plugin-0-4-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-dashboards"}, {"type": "npm", "path": "./ui-dashboards/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/dashboards-console-plugin-0-4-1-2-push.yaml
+++ b/.tekton/dashboards-console-plugin-0-4-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-dashboards"}, {"type": "npm", "path": "./ui-dashboards/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/distributed-tracing-console-plugin-0-3-1-2-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-distributed-tracing-pf4"}, {"type": "npm", "path": "./ui-distributed-tracing-pf4/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/distributed-tracing-console-plugin-0-3-1-2-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-3-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-distributed-tracing-pf4"}, {"type": "npm", "path": "./ui-distributed-tracing-pf4/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/distributed-tracing-console-plugin-0-4-1-2-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-4-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-distributed-tracing"}, {"type": "npm", "path": "./ui-distributed-tracing/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/distributed-tracing-console-plugin-0-4-1-2-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-0-4-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-distributed-tracing"}, {"type": "npm", "path": "./ui-distributed-tracing/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/korrel8r-1-2-pull-request.yaml
+++ b/.tekton/korrel8r-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./korrel8r"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/korrel8r-1-2-push.yaml
+++ b/.tekton/korrel8r-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./korrel8r"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/logging-console-plugin-6-0-1-2-pull-request.yaml
+++ b/.tekton/logging-console-plugin-6-0-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-logging-pf4"}, {"type": "npm", "path": "./ui-logging-pf4/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/logging-console-plugin-6-0-1-2-push.yaml
+++ b/.tekton/logging-console-plugin-6-0-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-logging-pf4"}, {"type": "npm", "path": "./ui-logging-pf4/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/logging-console-plugin-6-1-1-2-pull-request.yaml
+++ b/.tekton/logging-console-plugin-6-1-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-logging"}, {"type": "npm", "path": "./ui-logging/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/logging-console-plugin-6-1-1-2-push.yaml
+++ b/.tekton/logging-console-plugin-6-1-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-logging"}, {"type": "npm", "path": "./ui-logging/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/monitoring-console-plugin-0-4-1-2-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-0-4-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-monitoring"}, {"type": "npm", "path": "./ui-monitoring/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/monitoring-console-plugin-0-4-1-2-push.yaml
+++ b/.tekton/monitoring-console-plugin-0-4-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-monitoring"}, {"type": "npm", "path": "./ui-monitoring/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/obo-prometheus-operator-1-2-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./obo-prometheus-operator"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/obo-prometheus-operator-1-2-push.yaml
+++ b/.tekton/obo-prometheus-operator-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./obo-prometheus-operator"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-2-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./obo-prometheus-operator"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-2-push.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./obo-prometheus-operator"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-2-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./obo-prometheus-operator"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-2-push.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./obo-prometheus-operator"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-0-50-1-2-pull-request.yaml
+++ b/.tekton/perses-0-50-1-2-pull-request.yaml
@@ -46,7 +46,7 @@ spec:
     - name: hermetic
       value: "true"
     - name: prefetch-input
-      value: '[{"type": "gomod", "path": "./perses"}]'
+      value: '[{"type": "gomod", "path": "./perses"}, {"type":  "rpm"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-0-50-1-2-pull-request.yaml
+++ b/.tekton/perses-0-50-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./perses"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-0-50-1-2-pull-request.yaml
+++ b/.tekton/perses-0-50-1-2-pull-request.yaml
@@ -100,6 +100,10 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
+      - default: "false"
+        description: Enable dev-package-managers in prefetch task
+        name: prefetch-dev-package-managers-enabled
+        type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
@@ -202,6 +206,8 @@ spec:
             value: $(params.output-image).prefetch
           - name: ociArtifactExpiresAfter
             value: $(params.image-expires-after)
+          - name: dev-package-managers
+            value: $(params.prefetch-dev-package-managers-enabled)
         runAfter:
           - clone-repository
         taskRef:

--- a/.tekton/perses-0-50-1-2-pull-request.yaml
+++ b/.tekton/perses-0-50-1-2-pull-request.yaml
@@ -47,6 +47,8 @@ spec:
       value: "true"
     - name: prefetch-input
       value: '[{"type": "gomod", "path": "./perses"}, {"type":  "rpm"}]'
+    - name: prefetch-dev-package-managers-enabled
+      value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-0-50-1-2-push.yaml
+++ b/.tekton/perses-0-50-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./perses"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-0-50-1-2-push.yaml
+++ b/.tekton/perses-0-50-1-2-push.yaml
@@ -98,6 +98,10 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
+      - default: "false"
+        description: Enable dev-package-managers in prefetch task
+        name: prefetch-dev-package-managers-enabled
+        type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
@@ -200,6 +204,8 @@ spec:
             value: $(params.output-image).prefetch
           - name: ociArtifactExpiresAfter
             value: $(params.image-expires-after)
+          - name: dev-package-managers
+            value: $(params.prefetch-dev-package-managers-enabled)
         runAfter:
           - clone-repository
         taskRef:

--- a/.tekton/perses-0-50-1-2-push.yaml
+++ b/.tekton/perses-0-50-1-2-push.yaml
@@ -44,7 +44,7 @@ spec:
     - name: hermetic
       value: "true"
     - name: prefetch-input
-      value: '[{"type": "gomod", "path": "./perses"}]'
+      value: '[{"type": "gomod", "path": "./perses"}, {"type":  "rpm"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-0-50-1-2-push.yaml
+++ b/.tekton/perses-0-50-1-2-push.yaml
@@ -45,6 +45,8 @@ spec:
       value: "true"
     - name: prefetch-input
       value: '[{"type": "gomod", "path": "./perses"}, {"type":  "rpm"}]'
+    - name: prefetch-dev-package-managers-enabled
+      value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-operator-0-1-1-2-pull-request.yaml
+++ b/.tekton/perses-operator-0-1-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./perses-operator"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-operator-0-1-1-2-pull-request.yaml
+++ b/.tekton/perses-operator-0-1-1-2-pull-request.yaml
@@ -48,7 +48,7 @@ spec:
     - name: prefetch-input
       value: '[{"type": "gomod", "path": "./perses-operator"}, {"type":  "rpm"}]'
     - name: prefetch-dev-package-managers-enabled
-      value: "true"      
+      value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-operator-0-1-1-2-pull-request.yaml
+++ b/.tekton/perses-operator-0-1-1-2-pull-request.yaml
@@ -46,7 +46,7 @@ spec:
     - name: hermetic
       value: "true"
     - name: prefetch-input
-      value: '[{"type": "gomod", "path": "./perses-operator"}]'
+      value: '[{"type": "gomod", "path": "./perses-operator"}, {"type":  "rpm"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-operator-0-1-1-2-pull-request.yaml
+++ b/.tekton/perses-operator-0-1-1-2-pull-request.yaml
@@ -100,6 +100,10 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
+      - default: "false"
+        description: Enable dev-package-managers in prefetch task
+        name: prefetch-dev-package-managers-enabled
+        type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
@@ -202,6 +206,8 @@ spec:
             value: $(params.output-image).prefetch
           - name: ociArtifactExpiresAfter
             value: $(params.image-expires-after)
+          - name: dev-package-managers
+            value: $(params.prefetch-dev-package-managers-enabled)
         runAfter:
           - clone-repository
         taskRef:

--- a/.tekton/perses-operator-0-1-1-2-pull-request.yaml
+++ b/.tekton/perses-operator-0-1-1-2-pull-request.yaml
@@ -47,6 +47,8 @@ spec:
       value: "true"
     - name: prefetch-input
       value: '[{"type": "gomod", "path": "./perses-operator"}, {"type":  "rpm"}]'
+    - name: prefetch-dev-package-managers-enabled
+      value: "true"      
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-operator-0-1-1-2-push.yaml
+++ b/.tekton/perses-operator-0-1-1-2-push.yaml
@@ -46,7 +46,7 @@ spec:
     - name: prefetch-input
       value: '[{"type": "gomod", "path": "./perses-operator"}, {"type":  "rpm"}]'
     - name: prefetch-dev-package-managers-enabled
-      value: "true"      
+      value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-operator-0-1-1-2-push.yaml
+++ b/.tekton/perses-operator-0-1-1-2-push.yaml
@@ -98,6 +98,10 @@ spec:
         description: Execute the build with network isolation
         name: hermetic
         type: string
+      - default: "false"
+        description: Enable dev-package-managers in prefetch task
+        name: prefetch-dev-package-managers-enabled
+        type: string
       - default: ""
         description: Build dependencies to be prefetched by Cachi2
         name: prefetch-input
@@ -200,6 +204,8 @@ spec:
             value: $(params.output-image).prefetch
           - name: ociArtifactExpiresAfter
             value: $(params.image-expires-after)
+          - name: dev-package-managers
+            value: $(params.prefetch-dev-package-managers-enabled)
         runAfter:
           - clone-repository
         taskRef:

--- a/.tekton/perses-operator-0-1-1-2-push.yaml
+++ b/.tekton/perses-operator-0-1-1-2-push.yaml
@@ -44,7 +44,7 @@ spec:
     - name: hermetic
       value: "true"
     - name: prefetch-input
-      value: '[{"type": "gomod", "path": "./perses-operator"}]'
+      value: '[{"type": "gomod", "path": "./perses-operator"}, {"type":  "rpm"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-operator-0-1-1-2-push.yaml
+++ b/.tekton/perses-operator-0-1-1-2-push.yaml
@@ -45,6 +45,8 @@ spec:
       value: "true"
     - name: prefetch-input
       value: '[{"type": "gomod", "path": "./perses-operator"}, {"type":  "rpm"}]'
+    - name: prefetch-dev-package-managers-enabled
+      value: "true"      
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-operator-0-1-1-2-push.yaml
+++ b/.tekton/perses-operator-0-1-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./perses-operator"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/prometheus-1-2-pull-request.yaml
+++ b/.tekton/prometheus-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./prometheus"}, {"type": "npm", "path": "./prometheus/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/prometheus-1-2-push.yaml
+++ b/.tekton/prometheus-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./prometheus"}, {"type": "npm", "path": "./prometheus/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/troubleshooting-panel-console-plugin-0-4-1-2-pull-request.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-4-1-2-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-troubleshooting-panel"}, {"type": "npm", "path": "./ui-troubleshooting-panel/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/troubleshooting-panel-console-plugin-0-4-1-2-push.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-4-1-2-push.yaml
@@ -41,6 +41,10 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: hermetic
+      value: "true"
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./ui-troubleshooting-panel"}, {"type": "npm", "path": "./ui-troubleshooting-panel/web"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
Enabled hermetic build (setting lost from 1.1 to 1.2 configuration) for:

- coo
- dashboards
- distributed-tracing
- korrel8r
- logging
- monitoring
- obo-prometheus*
- perses
- perser-operator
- troubleshooting