### PR TITLE
alertmanager enable hermetic builds.

### DIFF
--- a/.tekton/alertmanager-1-2-pull-request.yaml
+++ b/.tekton/alertmanager-1-2-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./alertmanager"}, {"type": "npm", "path":"./alertmanager/ui/react-app"}]'
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/alertmanager-rhel9:on-pr-{{revision}}
     - name: image-expires-after
@@ -34,7 +38,7 @@ spec:
     - name: build-platforms
       value:
         - linux/x86_64
-        - linux/arm64
+        - linux-mxlarge/arm64
         - linux/ppc64le
         - linux/s390x
     - name: dockerfile

--- a/.tekton/alertmanager-1-2-push.yaml
+++ b/.tekton/alertmanager-1-2-push.yaml
@@ -27,12 +27,16 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: '[{"type": "gomod", "path": "./alertmanager"}, {"type": "npm", "path":"./alertmanager/ui/react-app"}]'
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/alertmanager-rhel9:{{revision}}
     - name: build-platforms
       value:
         - linux/x86_64
-        - linux/arm64
+        - linux-mxlarge/arm64
         - linux/ppc64le
         - linux/s390x
     - name: dockerfile

--- a/Dockerfile.alertmanager
+++ b/Dockerfile.alertmanager
@@ -46,4 +46,4 @@ LABEL com.redhat.component="coo-alertmanager" \
       io.k8s.display-name="Alertmanager" \
       io.k8s.description="Alertmanager handles alerts sent by client applications such as the Prometheus server" \
       maintainer="OpenShift Monitoring team <team-monitoring-incluster@redhat.com>" \
-      description="Alertmanager for Cluster Observability Operator" \
+      description="Alertmanager for Cluster Observability Operator"


### PR DESCRIPTION
This commit enables hermetic builds in alertmanager's konflux pipelines.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>
