### PR TITLE
fix: revert wrong mintmaker submodules change

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,10 +26,6 @@
 	path = ui-troubleshooting-panel
 	url = https://github.com/openshift/troubleshooting-panel-console-plugin.git
 	branch = release-0.4
-[submodule "ui-distributed-tracing"]
-	path = ui-distributed-tracing
-	url = https://github.com/openshift/distributed-tracing-console-plugin.git
-	branch = release-0.4
 [submodule "ui-monitoring"]
 	path = ui-monitoring
 	url = https://github.com/openshift/monitoring-plugin.git
@@ -53,7 +49,7 @@
 [submodule "cluster-health-analyzer"]
 	path = cluster-health-analyzer
 	url = https://github.com/openshift/cluster-health-analyzer
-	branch = release-0.4
+	branch = release-0.5
 [submodule "ui-logging-pf4"]
 	path = ui-logging-pf4
 	url = https://github.com/openshift/logging-view-plugin.git
@@ -62,3 +58,11 @@
 	path = ui-distributed-tracing-pf4
 	url = https://github.com/openshift/distributed-tracing-console-plugin.git
 	branch = release-0.3
+[submodule "ui-distributed-tracing-pf5"]
+	path = ui-distributed-tracing-pf5
+	url = https://github.com/openshift/distributed-tracing-console-plugin.git
+	branch = release-0.4
+[submodule "ui-distributed-tracing"]
+	path = ui-distributed-tracing
+	url = https://github.com/openshift/distributed-tracing-console-plugin.git
+	branch = release-1.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -41,7 +41,7 @@
 [submodule "korrel8r"]
         path = korrel8r
         url = https://github.com/korrel8r/korrel8r.git
-        branch = v0.8
+        branch = release-coo-1.2
 [submodule "perses-operator"]
 	path = perses-operator
 	url = https://github.com/perses/perses-operator

--- a/.tekton/alertmanager-1-2-pull-request.yaml
+++ b/.tekton/alertmanager-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/alertmanager-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/alertmanager-1-2-push.yaml".pathChanged() ||
               "Dockerfile.alertmanager".pathChanged() ||
-              "alertmanager/***".pathChanged())
+              "alertmanager".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/alertmanager-1-2-push.yaml
+++ b/.tekton/alertmanager-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/alertmanager-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/alertmanager-1-2-push.yaml".pathChanged() ||
               "Dockerfile.alertmanager".pathChanged() ||
-              "alertmanager/***".pathChanged())
+              "alertmanager".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/cluster-health-analyzer-1-2-pull-request.yaml
+++ b/.tekton/cluster-health-analyzer-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/cluster-health-analyzer-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/cluster-health-analyzer-1-2-push.yaml".pathChanged() ||
               "Dockerfile.cluster-health-analyzer".pathChanged() ||
-              "cluster-health-analyzer/***".pathChanged())
+              "cluster-health-analyzer".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/cluster-health-analyzer-1-2-push.yaml
+++ b/.tekton/cluster-health-analyzer-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/cluster-health-analyzer-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/cluster-health-analyzer-1-2-push.yaml".pathChanged() ||
               "Dockerfile.cluster-health-analyzer".pathChanged() ||
-              "cluster-health-analyzer/***".pathChanged())
+              "cluster-health-analyzer".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/cluster-observability-operator-1-2-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/cluster-observability-operator-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/cluster-observability-operator-1-2-push.yaml".pathChanged() ||
               "Dockerfile.obo".pathChanged() ||
-              "observability-operator/***".pathChanged())
+              "observability-operator".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/cluster-observability-operator-1-2-push.yaml
+++ b/.tekton/cluster-observability-operator-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/cluster-observability-operator-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/cluster-observability-operator-1-2-push.yaml".pathChanged() ||
               "Dockerfile.obo".pathChanged() ||
-              "observability-operator/***".pathChanged())
+              "observability-operator".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/dashboards-console-plugin-0-4-1-2-pull-request.yaml
+++ b/.tekton/dashboards-console-plugin-0-4-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/dashboards-console-plugin-0-4-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/dashboards-console-plugin-0-4-1-2-push.yaml".pathChanged() ||
               "Dockerfile.ui-dashboards".pathChanged() ||
-              "ui-dashboards/***".pathChanged())
+              "ui-dashboards".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/dashboards-console-plugin-0-4-1-2-push.yaml
+++ b/.tekton/dashboards-console-plugin-0-4-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/dashboards-console-plugin-0-4-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/dashboards-console-plugin-0-4-1-2-push.yaml".pathChanged() ||
               "Dockerfile.ui-dashboards".pathChanged() ||
-              "ui-dashboards/***".pathChanged())
+              "ui-dashboards".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/korrel8r-1-2-pull-request.yaml
+++ b/.tekton/korrel8r-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/korrel8r-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/korrel8r-1-2-push.yaml".pathChanged() ||
               "Dockerfile.korrel8r".pathChanged() ||
-              "korrel8r/***".pathChanged())
+              "korrel8r".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/korrel8r-1-2-push.yaml
+++ b/.tekton/korrel8r-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/korrel8r-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/korrel8r-1-2-push.yaml".pathChanged() ||
               "Dockerfile.korrel8r".pathChanged() ||
-              "korrel8r/***".pathChanged())
+              "korrel8r".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/logging-console-plugin-6-0-1-2-pull-request.yaml
+++ b/.tekton/logging-console-plugin-6-0-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/logging-console-plugin-6-0-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/logging-console-plugin-6-0-1-2-push.yaml".pathChanged() ||
               "Dockerfile.ui-logging-pf4".pathChanged() ||
-              "ui-logging-pf4/***".pathChanged())
+              "ui-logging-pf4".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/logging-console-plugin-6-0-1-2-push.yaml
+++ b/.tekton/logging-console-plugin-6-0-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/logging-console-plugin-6-0-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/logging-console-plugin-6-0-1-2-push.yaml".pathChanged() ||
               "Dockerfile.ui-logging-pf4".pathChanged() ||
-              "ui-logging-pf4/***".pathChanged())
+              "ui-logging-pf4".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/logging-console-plugin-6-1-1-2-pull-request.yaml
+++ b/.tekton/logging-console-plugin-6-1-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/logging-console-plugin-6-1-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/logging-console-plugin-6-1-1-2-push.yaml".pathChanged() ||
               "Dockerfile.ui-logging".pathChanged() ||
-              "ui-logging/***".pathChanged())
+              "ui-logging".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/logging-console-plugin-6-1-1-2-push.yaml
+++ b/.tekton/logging-console-plugin-6-1-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/logging-console-plugin-6-1-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/logging-console-plugin-6-1-1-2-push.yaml".pathChanged() ||
               "Dockerfile.ui-logging".pathChanged() ||
-              "ui-logging/***".pathChanged())
+              "ui-logging".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/monitoring-console-plugin-0-4-1-2-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-0-4-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/monitoring-console-plugin-0-4-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/monitoring-console-plugin-0-4-1-2-push.yaml".pathChanged() ||
               "Dockerfile.ui-monitoring".pathChanged() ||
-              "ui-monitoring/***".pathChanged())
+              "ui-monitoring".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/monitoring-console-plugin-0-4-1-2-push.yaml
+++ b/.tekton/monitoring-console-plugin-0-4-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/monitoring-console-plugin-0-4-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/monitoring-console-plugin-0-4-1-2-push.yaml".pathChanged() ||
               "Dockerfile.ui-monitoring".pathChanged() ||
-              "ui-monitoring/***".pathChanged())
+              "ui-monitoring".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/obo-prometheus-operator-1-2-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/obo-prometheus-operator-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/obo-prometheus-operator-1-2-push.yaml".pathChanged() ||
               "Dockerfile.prom-op".pathChanged() ||
-              "obo-prometheus-operator/***".pathChanged())
+              "obo-prometheus-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/obo-prometheus-operator-1-2-push.yaml
+++ b/.tekton/obo-prometheus-operator-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/obo-prometheus-operator-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/obo-prometheus-operator-1-2-push.yaml".pathChanged() ||
               "Dockerfile.prom-op".pathChanged() ||
-              "obo-prometheus-operator/***".pathChanged())
+              "obo-prometheus-operator".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-2-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/obo-prometheus-operator-admission-webhook-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/obo-prometheus-operator-admission-webhook-1-2-push.yaml".pathChanged() ||
               "Dockerfile.p-o-admission-webhook".pathChanged() ||
-              "obo-prometheus-operator/***".pathChanged())
+              "obo-prometheus-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-2-push.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/obo-prometheus-operator-admission-webhook-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/obo-prometheus-operator-admission-webhook-1-2-push.yaml".pathChanged() ||
               "Dockerfile.p-o-admission-webhook".pathChanged() ||
-              "obo-prometheus-operator/***".pathChanged())
+              "obo-prometheus-operator".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-2-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/obo-prometheus-operator-prometheus-config-reloader-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/obo-prometheus-operator-prometheus-config-reloader-1-2-push.yaml".pathChanged() ||
               "Dockerfile.prometheus-config-reloader".pathChanged() ||
-              "obo-prometheus-operator/***".pathChanged())
+              "obo-prometheus-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-2-push.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/obo-prometheus-operator-prometheus-config-reloader-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/obo-prometheus-operator-prometheus-config-reloader-1-2-push.yaml".pathChanged() ||
               "Dockerfile.prometheus-config-reloader".pathChanged() ||
-              "obo-prometheus-operator/***".pathChanged())
+              "obo-prometheus-operator".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/perses-0-50-1-2-pull-request.yaml
+++ b/.tekton/perses-0-50-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/perses-0-50-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/perses-0-50-1-2-push.yaml".pathChanged() ||
               "Dockerfile.perses".pathChanged() ||
-              "perses/***".pathChanged())
+              "perses".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/perses-0-50-1-2-push.yaml
+++ b/.tekton/perses-0-50-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/perses-0-50-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/perses-0-50-1-2-push.yaml".pathChanged() ||
               "Dockerfile.perses".pathChanged() ||
-              "perses/***".pathChanged())
+              "perses".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/perses-operator-0-1-1-2-pull-request.yaml
+++ b/.tekton/perses-operator-0-1-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/perses-operator-0-1-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/perses-operator-0-1-1-2-push.yaml".pathChanged() ||
               "Dockerfile.perses-operator".pathChanged() ||
-              "perses-operator/***".pathChanged())
+              "perses-operator".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/perses-operator-0-1-1-2-push.yaml
+++ b/.tekton/perses-operator-0-1-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/perses-operator-0-1-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/perses-operator-0-1-1-2-push.yaml".pathChanged() ||
               "Dockerfile.perses-operator".pathChanged() ||
-              "perses-operator/***".pathChanged())
+              "perses-operator".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/prometheus-1-2-pull-request.yaml
+++ b/.tekton/prometheus-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/prometheus-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/prometheus-1-2-push.yaml".pathChanged() ||
               "Dockerfile.prometheus".pathChanged() ||
-              "prometheus/***".pathChanged())
+              "prometheus".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/prometheus-1-2-push.yaml
+++ b/.tekton/prometheus-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/prometheus-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/prometheus-1-2-push.yaml".pathChanged() ||
               "Dockerfile.prometheus".pathChanged() ||
-              "prometheus/***".pathChanged())
+              "prometheus".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/thanos-1-2-pull-request.yaml
+++ b/.tekton/thanos-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/thanos-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/thanos-1-2-push.yaml".pathChanged() ||
               "Dockerfile.thanos".pathChanged() ||
-              "thanos/***".pathChanged())
+              "thanos".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/thanos-1-2-push.yaml
+++ b/.tekton/thanos-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/thanos-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/thanos-1-2-push.yaml".pathChanged() ||
               "Dockerfile.thanos".pathChanged() ||
-              "thanos/***".pathChanged())
+              "thanos".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:

--- a/.tekton/troubleshooting-panel-console-plugin-0-4-1-2-pull-request.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-4-1-2-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
               (".tekton/troubleshooting-panel-console-plugin-0-4-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/troubleshooting-panel-console-plugin-0-4-1-2-push.yaml".pathChanged() ||
               "Dockerfile.ui-troubleshooting-panel".pathChanged() ||
-              "ui-troubleshooting-panel/***".pathChanged())
+              "ui-troubleshooting-panel".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cluster-observability-operator-1-2

--- a/.tekton/troubleshooting-panel-console-plugin-0-4-1-2-push.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-0-4-1-2-push.yaml
@@ -12,7 +12,7 @@ metadata:
               (".tekton/troubleshooting-panel-console-plugin-0-4-1-2-pull-request.yaml".pathChanged() ||
               ".tekton/troubleshooting-panel-console-plugin-0-4-1-2-push.yaml".pathChanged() ||
               "Dockerfile.ui-troubleshooting-panel".pathChanged() ||
-              "ui-troubleshooting-panel/***".pathChanged())
+              "ui-troubleshooting-panel".pathChanged())
     build.appstudio.openshift.io/build-nudge-files: bundle-patches/render_templates
   creationTimestamp: null
   labels:


### PR DESCRIPTION
- Reverts https://github.com/rhobs/konflux-coo/pull/1116 and https://github.com/rhobs/konflux-coo/pull/1117 (See https://github.com/rhobs/konflux-coo/pull/1116#issuecomment-2895134441)
- Fixes CEL expressions to trigger the right build