### PR TITLE
Bump obo to 1.2 in COO

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "observability-operator"]
 	path = observability-operator
 	url = https://github.com/rhobs/observability-operator
-        branch = release-1.1
+    branch = release-1.2
 [submodule "ui-logging"]
 	path = ui-logging
 	url = https://github.com/openshift/logging-view-plugin.git


### PR DESCRIPTION
This commit bumps the obo submodule usage to 1.2 in COO.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>