### PR TITLE
Revert "COO-951: upgrade Perses operator to v0.1.12"

### DIFF
--- a/Dockerfile.perses-operator
+++ b/Dockerfile.perses-operator
@@ -1,11 +1,10 @@
-FROM golang:1.24 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 as builder
 
 USER root
 
-# This might be needed when using brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24
-# RUN dnf install -y --setopt=tsflags=nodocs mailcap && \
-#     dnf clean all && \
-#     rm -rf /var/cache/dnf
+RUN dnf install -y --setopt=tsflags=nodocs mailcap && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 WORKDIR /app
 
@@ -28,7 +27,7 @@ ENTRYPOINT [ "/bin/manager" ]
 
 LABEL com.redhat.component="coo-perses-operator" \
     name="perses/perses-operator" \
-    version="v0.1.12" \
+    version="v0.1.10" \
     summary="Perses Operator for Cluster Observability Operator" \
     io.openshift.tags="openshift,observability-ui,perses-operator" \
     io.k8s.display-name="Perses Operator for Cluster Observability Operator" \


### PR DESCRIPTION
Reverts rhobs/konflux-coo#1174

a critical compliance violation was identified: the use of docker.io/library/golang as an image source. This registry is not permitted for production environment