### PR TITLE
Build perses-operator v0.1.12 from rhobs fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,8 +44,8 @@
         branch = release-coo-1.2
 [submodule "perses-operator"]
 	path = perses-operator
-	url = https://github.com/perses/perses-operator
-	branch = release/v0.1
+	url = https://github.com/rhobs/perses-operator
+	branch = v0.1.12-golang_1_23
 [submodule "perses"]
 	path = perses
 	url = https://github.com/perses/perses.git

--- a/Dockerfile.perses-operator
+++ b/Dockerfile.perses-operator
@@ -27,7 +27,7 @@ ENTRYPOINT [ "/bin/manager" ]
 
 LABEL com.redhat.component="coo-perses-operator" \
     name="perses/perses-operator" \
-    version="v0.1.10" \
+    version="v0.1.12" \
     summary="Perses Operator for Cluster Observability Operator" \
     io.openshift.tags="openshift,observability-ui,perses-operator" \
     io.k8s.display-name="Perses Operator for Cluster Observability Operator" \


### PR DESCRIPTION
This commit modifies the gitmodule so perses-operator is built from the
rhobs fork and with golang 1.23 as a builder.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>
