### PR TITLE
OU-853: [COO 1.2.1] update perses-operator submodule 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,7 +45,7 @@
 [submodule "perses-operator"]
 	path = perses-operator
 	url = https://github.com/rhobs/perses-operator
-	branch = v0.1.12-golang_1_23
+	branch = v0.2.0-golang_1_23
 [submodule "perses"]
 	path = perses
 	url = https://github.com/rhobs/perses.git


### PR DESCRIPTION
### Description
- Update .gitmodules to point to new release branch for COO 1.2.1 https://github.com/rhobs/perses-operator/commits/v0.2.0-golang_1_23
- Update /perses-operator submodule commit hash 

### JIRA
https://issues.redhat.com/browse/OU-853

### Notes 
No Dockerfile.perses-operator changes are necessary as confirmed in [Slack](https://redhat-internal.slack.com/archives/C07RV4GPQSV/p1750267904464669) 