### PR TITLE
create release staging for 1.2.1

### DIFF
--- a/hack/update-fbc.sh
+++ b/hack/update-fbc.sh
@@ -15,9 +15,9 @@ update_single_fbc() {
         return 1
     fi
     
-    sed -i "s/\(snapshot: \).*/\1$latest_snap/" "$file"
+    sed -i "s/\(snapshot:\).*/\1 $latest_snap/" "$file"
     now=$(date +%Y-%m-%d-%H-%M)
-    sed -i "s/\(name: \).*/\1$latest_snap-$now/" "$file"
+    sed -i "s/\(name:\).*/\1 $latest_snap-$now/" "$file"
 }
 
 # Function to update all FBC files given a directory and environment

--- a/hack/update-fbc.sh
+++ b/hack/update-fbc.sh
@@ -14,6 +14,8 @@ update_single_fbc() {
         echo "Error: No latest snapshot found for component coo-$fbc to update file $file"
         return 1
     fi
+
+    echo "Updating $file with latest snapshot: $latest_snap"
     
     sed -i "s/\(snapshot:\).*/\1 $latest_snap/" "$file"
     now=$(date +%Y-%m-%d-%H-%M)

--- a/hack/update-fbc.sh
+++ b/hack/update-fbc.sh
@@ -1,11 +1,77 @@
 #!/bin/bash
-# run like so:
-# for f in release-payloads/release-1.2.0/release-stage-fbc-v4-*; do bash hack/update-fbc.sh $f; done
 
-pipeline="$(basename "$1")"
-fbc="${pipeline:14}"
-fbc="${fbc%.yaml}"
-latest_snap=$(kubectl get snapshots -l appstudio.openshift.io/component=coo-"$fbc" --sort-by='.metadata.creationTimestamp' --no-headers -o custom-columns=":metadata.name" | tail -n 3 | tac | xargs kubectl get snapshots -o json | jq -r ".items[] | select(.metadata.labels.\"appstudio.openshift.io/build-pipelinerun\" | startswith(\"coo-$fbc-on-push\")).metadata.name" | head -n1)
-sed -i "s/\(snapshot: \).*/\1$latest_snap/" "$1"
-now=$(date +%Y-%m-%d-%H-%M)
-sed -i "s/\(name: \).*/\1$latest_snap-$now/" "$1"
+# Function to update a single FBC file
+update_single_fbc() {
+    local file="$1"
+    local env="$2"
+    pipeline="$(basename "$file")"
+    fbc="${pipeline:14}"
+    fbc="${fbc%.yaml}"
+    
+    latest_snap=$(kubectl get snapshots -l appstudio.openshift.io/component=coo-"$fbc" --sort-by='.metadata.creationTimestamp' --no-headers -o custom-columns=":metadata.name" | tail -n 3 | tac | xargs kubectl get snapshots -o json | jq -r ".items[] | select(.metadata.labels.\"appstudio.openshift.io/build-pipelinerun\" | startswith(\"coo-$fbc-on-push\")).metadata.name" | head -n1)
+    
+    if [[ -z "$latest_snap" ]]; then
+        echo "Error: No latest snapshot found for component coo-$fbc to update file $file"
+        return 1
+    fi
+    
+    sed -i "s/\(snapshot: \).*/\1$latest_snap/" "$file"
+    now=$(date +%Y-%m-%d-%H-%M)
+    sed -i "s/\(name: \).*/\1$latest_snap-$now/" "$file"
+}
+
+# Function to update all FBC files given a directory and environment
+update_all_fbc() {
+    local release_dir="$1"
+    local env="$2"
+    
+    local file_pattern="release-stage-fbc-v4-*"
+    if [[ "$env" == "prod" ]]; then
+        file_pattern="release-prod-fbc-v4-*"
+    fi
+    
+    for f in "$release_dir"/$file_pattern; do
+        if [[ -f "$f" ]]; then
+            echo "Processing $f..."
+            update_single_fbc "$f" "$env"
+        fi
+    done
+}
+
+env="stage"
+target=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --env)
+            env="$2"
+            if [[ "$env" != "stage" && "$env" != "prod" ]]; then
+                echo "Error: Environment must be 'stage' or 'prod'"
+                exit 1
+            fi
+            shift 2
+            ;;
+        *)
+            target="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -n "$target" ]]; then
+    if [[ -f "$target" ]]; then
+        update_single_fbc "$target"
+    elif [[ -d "$target" ]]; then
+        echo "Processing directory $target for $env environment"
+        update_all_fbc "$target" "$env"
+    else
+        echo "Error: $target is not a valid file or directory"
+        exit 1
+    fi
+else
+    echo "Usage: $0 [--env stage|prod] <file_or_directory>"
+    echo "  Single file: $0 release-payloads/release-1.2.0/release-stage-fbc-v4-example.yaml"
+    echo "  Directory:   $0 --env prod release-payloads/release-1.2.0/"
+    echo "  Default env for directory: stage"
+    exit 1
+fi

--- a/hack/update-fbc.sh
+++ b/hack/update-fbc.sh
@@ -3,7 +3,8 @@
 # for f in release-payloads/release-1.2.0/release-stage-fbc-v4-*; do bash hack/update-fbc.sh $f; done
 
 pipeline="$(basename "$1")"
-fbc="${pipeline:14:(-5)}"
+fbc="${pipeline:14}"
+fbc="${fbc%.yaml}"
 latest_snap=$(kubectl get snapshots -l appstudio.openshift.io/component=coo-"$fbc" --sort-by='.metadata.creationTimestamp' --no-headers -o custom-columns=":metadata.name" | tail -n 3 | tac | xargs kubectl get snapshots -o json | jq -r ".items[] | select(.metadata.labels.\"appstudio.openshift.io/build-pipelinerun\" | startswith(\"coo-$fbc-on-push\")).metadata.name" | head -n1)
 sed -i "s/\(snapshot: \).*/\1$latest_snap/" "$1"
 now=$(date +%Y-%m-%d-%H-%M)

--- a/release-payloads/release-1.2.1/release-stage-bundle.yaml
+++ b/release-payloads/release-1.2.1/release-stage-bundle.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  namespace: cluster-observabilit-tenant
+  name: coo-1.2.1-stage-release-x97hm-2025-06-25-17-44
+spec:
+  releasePlan: cluster-observability-operator-1-2-stage
+  snapshot: cluster-observability-operator-1-2-x97hm
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: 'Cluster Observability Operator 1.2.1 release - staging.'
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-12.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-12.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-12-ptb6h-2025-06-26-09-41
+  name: coo-fbc-v4-12-ptb6h-2025-06-26-09-50
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-12-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-12.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-12.yaml
@@ -2,11 +2,11 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: -2025-06-25-18-00
+  name: coo-fbc-v4-12-ptb6h-2025-06-26-09-41
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-12-staging-release-plan
-  snapshot: 
+  snapshot: coo-fbc-v4-12-ptb6h
   data:
     releaseNotes:
       type: RHBA

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-12.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-12.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-12-ptb6h-2025-06-26-09-50
+  name: coo-fbc-v4-12-ptb6h-2025-06-26-10-30
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-12-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-12.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-12.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: -2025-06-25-18-00
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-12-staging-release-plan
+  snapshot: 
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.12 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-13.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-13.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-13-726dp-2025-06-25-18-00
+  name: coo-fbc-v4-13-726dp-2025-06-26-09-41
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-13-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-13.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-13.yaml
@@ -2,11 +2,11 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-13-726dp-2025-06-26-09-50
+  name: coo-fbc-v4-13-m6wgn-2025-06-26-10-30
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-13-staging-release-plan
-  snapshot: coo-fbc-v4-13-726dp
+  snapshot: coo-fbc-v4-13-m6wgn
   data:
     releaseNotes:
       type: RHBA

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-13.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-13.yaml
@@ -2,11 +2,11 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-13-726dp-2025-06-26-09-41
+  name: coo-fbc-v4-13-726dp-2025-06-26-09-50
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-13-staging-release-plan
-  snapshot:
+  snapshot: coo-fbc-v4-13-726dp
   data:
     releaseNotes:
       type: RHBA

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-13.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-13.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-13-726dp-2025-06-25-18-00
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-13-staging-release-plan
+  snapshot:
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: 'Cluster Observability Operator 1.2.1 release - fbc 4.13 - staging.'
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-14.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-14.yaml
@@ -2,11 +2,11 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: -2025-06-25-18-00
+  name: coo-fbc-v4-14-lclhg-2025-06-26-09-41
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-14-staging-release-plan
-  snapshot: 
+  snapshot: coo-fbc-v4-14-lclhg
   data:
     releaseNotes:
       type: RHBA

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-14.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-14.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-14-lclhg-2025-06-26-09-50
+  name: coo-fbc-v4-14-lclhg-2025-06-26-10-31
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-14-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-14.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-14.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: -2025-06-25-18-00
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-14-staging-release-plan
+  snapshot: 
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.14 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-14.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-14.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-14-lclhg-2025-06-26-09-41
+  name: coo-fbc-v4-14-lclhg-2025-06-26-09-50
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-14-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-15.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-15.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-15-zrkbc-2025-06-26-09-50
+  name: coo-fbc-v4-15-zrkbc-2025-06-26-10-31
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-15-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-15.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-15.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-15-zrkbc-2025-06-26-09-41
+  name: coo-fbc-v4-15-zrkbc-2025-06-26-09-50
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-15-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-15.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-15.yaml
@@ -2,11 +2,11 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-15-p8hsr-2025-06-25-18-00
+  name: coo-fbc-v4-15-zrkbc-2025-06-26-09-41
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-15-staging-release-plan
-  snapshot: coo-fbc-v4-15-p8hsr
+  snapshot: coo-fbc-v4-15-zrkbc
   data:
     releaseNotes:
       type: RHBA

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-15.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-15.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-15-p8hsr-2025-06-25-18-00
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-15-staging-release-plan
+  snapshot: coo-fbc-v4-15-p8hsr
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.15 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-16.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-16.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-16-xcd4f-2025-06-26-09-50
+  name: coo-fbc-v4-16-xcd4f-2025-06-26-10-31
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-16-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-16.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-16.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-16-6sr24-2025-06-25-18-00
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-16-staging-release-plan
+  snapshot: coo-fbc-v4-16-6sr24
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.16 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-16.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-16.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-16-xcd4f-2025-06-26-09-41
+  name: coo-fbc-v4-16-xcd4f-2025-06-26-09-50
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-16-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-16.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-16.yaml
@@ -2,11 +2,11 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-16-6sr24-2025-06-25-18-00
+  name: coo-fbc-v4-16-xcd4f-2025-06-26-09-41
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-16-staging-release-plan
-  snapshot: coo-fbc-v4-16-6sr24
+  snapshot: coo-fbc-v4-16-xcd4f
   data:
     releaseNotes:
       type: RHBA

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-17.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-17.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: -2025-06-25-18-00
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-17-staging-release-plan
+  snapshot: 
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.17 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-17.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-17.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-17-8czm9-2025-06-26-09-50
+  name: coo-fbc-v4-17-8czm9-2025-06-26-10-31
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-17-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-17.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-17.yaml
@@ -2,11 +2,11 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: -2025-06-25-18-00
+  name: coo-fbc-v4-17-8czm9-2025-06-26-09-41
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-17-staging-release-plan
-  snapshot: 
+  snapshot: coo-fbc-v4-17-8czm9
   data:
     releaseNotes:
       type: RHBA

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-17.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-17.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-17-8czm9-2025-06-26-09-41
+  name: coo-fbc-v4-17-8czm9-2025-06-26-09-50
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-17-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-18.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-18.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-18-kphdf-2025-06-25-18-00
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-18-staging-release-plan
+  snapshot: coo-fbc-v4-18-kphdf
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.18 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-18.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-18.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-18-w2d2s-2025-06-26-09-51
+  name: coo-fbc-v4-18-w2d2s-2025-06-26-10-31
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-18-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-18.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-18.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-18-w2d2s-2025-06-26-09-41
+  name: coo-fbc-v4-18-w2d2s-2025-06-26-09-51
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-18-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-18.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-18.yaml
@@ -2,11 +2,11 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-18-kphdf-2025-06-25-18-00
+  name: coo-fbc-v4-18-w2d2s-2025-06-26-09-41
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-18-staging-release-plan
-  snapshot: coo-fbc-v4-18-kphdf
+  snapshot: coo-fbc-v4-18-w2d2s
   data:
     releaseNotes:
       type: RHBA

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-19.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-19.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-19-kpm2x-2025-06-25-18-00
+  name: coo-fbc-v4-19-kpm2x-2025-06-26-09-41
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-19-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-19.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-19.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-19-kpm2x-2025-06-26-09-41
+  name: coo-fbc-v4-19-kpm2x-2025-06-26-09-51
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-19-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-19.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-19.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-19-kpm2x-2025-06-25-18-00
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-19-staging-release-plan
+  snapshot: coo-fbc-v4-19-kpm2x
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.19 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-19.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-19.yaml
@@ -2,11 +2,11 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: coo-fbc-v4-19-kpm2x-2025-06-26-09-51
+  name: coo-fbc-v4-19-5jgkw-2025-06-26-10-31
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-19-staging-release-plan
-  snapshot: coo-fbc-v4-19-kpm2x
+  snapshot: coo-fbc-v4-19-5jgkw
   data:
     releaseNotes:
       type: RHBA

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-20.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-20.yaml
@@ -2,11 +2,11 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: -2025-06-26-09-22
+  name: coo-fbc-v4-20-z582g-2025-06-26-10-31
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-20-staging-release-plan
-  snapshot: 
+  snapshot: coo-fbc-v4-20-z582g
   data:
     releaseNotes:
       type: RHBA

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-20.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-20.yaml
@@ -2,7 +2,7 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: -2025-06-25-18-00
+  name: -2025-06-26-09-22
   namespace: cluster-observabilit-tenant
 spec:
   releasePlan: coo-fbc-v4-20-staging-release-plan

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-20.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-20.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: -2025-06-25-18-00
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-20-staging-release-plan
+  snapshot: 
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.4.20 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification


### PR DESCRIPTION
- I adjusted the `hack/update-fbc.sh` script so it works with mac. I hope it works for others
- We still need snapshots for the fbcs, they will be updated when we merge: https://github.com/rhobs/konflux-coo-fbc/pull/132 then wait for the pipeline, and run `update-fbc.sh`

Update:
- changed the script to loop over the fbcs or process a single one and display an error message when a snapshot is not found.