### PR TITLE
[COO 1.2.1] create release-stage-fbc for COO 1.2.1

### DIFF
--- a/hack/update-fbc.sh
+++ b/hack/update-fbc.sh
@@ -3,8 +3,10 @@
 # for f in release-payloads/release-1.2.0/release-stage-fbc-v4-*; do bash hack/update-fbc.sh $f; done
 
 pipeline="$(basename "$1")"
-fbc="${pipeline:14:(-5)}"
+fbc="${pipeline:14}"
+fbc="${fbc%.yaml}"
 latest_snap=$(kubectl get snapshots -l appstudio.openshift.io/component=coo-"$fbc" --sort-by='.metadata.creationTimestamp' --no-headers -o custom-columns=":metadata.name" | tail -n 3 | tac | xargs kubectl get snapshots -o json | jq -r ".items[] | select(.metadata.labels.\"appstudio.openshift.io/build-pipelinerun\" | startswith(\"coo-$fbc-on-push\")).metadata.name" | head -n1)
+echo "latest_snap: $latest_snap"
 sed -i "s/\(snapshot: \).*/\1$latest_snap/" "$1"
 now=$(date +%Y-%m-%d-%H-%M)
 sed -i "s/\(name: \).*/\1$latest_snap-$now/" "$1"

--- a/release-payloads/release-1.2.1/release-stage-bundle.yaml
+++ b/release-payloads/release-1.2.1/release-stage-bundle.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  namespace: cluster-observabilit-tenant
+  name: coo-1.2.1-stage-release-cgs9t
+spec:
+  releasePlan: cluster-observability-operator-1-2-stage
+  snapshot: cluster-observability-operator-1-2-cgs9t
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-12.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-12.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-12-ptb6h-2025-06-25-16-51
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-12-staging-release-plan
+  snapshot: coo-fbc-v4-12-ptb6h
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.12 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-13.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-13.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-13-726dp-2025-06-25-16-51
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-13-staging-release-plan
+  snapshot: coo-fbc-v4-13-726dp
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.13 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-14.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-14.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-14-f74v2-2025-06-25-16-51
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-14-staging-release-plan
+  snapshot: coo-fbc-v4-14-f74v2 
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.14 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-15.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-15.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-15-zrkbc-2025-06-25-16-51
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-15-staging-release-plan
+  snapshot: coo-fbc-v4-15-zrkbc
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.15 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-16.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-16.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-16-xcd4f-2025-06-25-16-51
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-16-staging-release-plan
+  snapshot: coo-fbc-v4-16-xcd4f
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.16 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-17.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-17.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-17-8czm9-2025-06-25-16-51
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-17-staging-release-plan
+  snapshot: coo-fbc-v4-17-8czm9
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.17 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-18.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-18.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-18-w2d2s-2025-06-25-16-51
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-18-staging-release-plan
+  snapshot: coo-fbc-v4-18-w2d2s
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.18 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-19.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-19.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-19-kpm2x-2025-06-25-16-51
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-19-staging-release-plan
+  snapshot: coo-fbc-v4-19-kpm2x
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.19 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification

--- a/release-payloads/release-1.2.1/release-stage-fbc-v4-20.yaml
+++ b/release-payloads/release-1.2.1/release-stage-fbc-v4-20.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: coo-fbc-v4-20-v7fd6-2025-06-25-16-51
+  namespace: cluster-observabilit-tenant
+spec:
+  releasePlan: coo-fbc-v4-20-staging-release-plan
+  snapshot: coo-fbc-v4-20-v7fd6 
+  data:
+    releaseNotes:
+      type: RHBA
+      topic: "Cluster Observability Operator 1.2.1 release - fbc 4.4.20 - staging."
+      issues:
+        fixed:
+          - id: COO-871
+            source: issues.redhat.com
+          - id: COO-870
+            source: issues.redhat.com
+          - id: COO-365
+            source: issues.redhat.com
+          - id: COO-357
+            source: issues.redhat.com
+      references:
+        - https://access.redhat.com/security/updates/classification


### PR DESCRIPTION
- Continuation of https://github.com/rhobs/konflux-coo/pull/1283
- Manual update of release-stage-fbc-v4-14.yaml and release-stage-fbc-v4-20.yaml  
   - metadata.name: [INSERTED-LATEST-SNAPSHOT]- 2025-06-25-18-00
   - spec.snapshot: [INSERTED-LATEST-SNAPSHOT] 

I found the latest snapshot by `kubectl get snapshots -l appstudio.openshift.io/component=coo-"fbc-v4-20" --sort-by='.metadata.creationTimestamp' ` in https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com

I looked into it and it seems like the snapshots weren’t matching `startswith(\"coo-$fbc-on-push\")).[metadata.name]` in the `update-fbc.sh` script. They had labels for `...-on-pull` instead of on `...-on-push` (e.g. “coo-fbc-v4-20-on-pull-request-snhbn”). Not sure it's critical for the snapshot to have this label...