### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cluster-observability-operator-1-2

### DIFF
--- a/Dockerfile.obo
+++ b/Dockerfile.obo
@@ -32,7 +32,8 @@ USER 65532:65532
 ENTRYPOINT ["/manager"]
 
 LABEL com.redhat.component="coo-operator" \
-      name="Cluster Observability Operator" \
+      name="cluster-observability-operator/cluster-observability-rhel9-operator" \
+      cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
       version="v1.2.2" \
       summary="Cluster Observability Operator" \
       io.openshift.tags="openshift,observability" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
