### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for dashboards-console-plugin-0-4-1-2

### DIFF
--- a/Dockerfile.ui-dashboards
+++ b/Dockerfile.ui-dashboards
@@ -44,7 +44,8 @@ COPY --from=go-builder /opt/app-root/plugin-backend /opt/app-root
 ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist"]
 
 LABEL com.redhat.component="coo-dashboards-console-plugin" \
-      name="openshift/dashboards-console-plugin" \
+      name="cluster-observability-operator/dashboards-console-plugin-0-4-rhel9" \
+      cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
       version="v0.4.0" \
       summary="OpenShift console plugin to enhance dashboards datasources" \
       io.openshift.tags="openshift,observability-ui" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
