### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for distributed-tracing-console-plugin-0-3-1-2

### DIFF
--- a/Dockerfile.ui-distributed-tracing-pf4
+++ b/Dockerfile.ui-distributed-tracing-pf4
@@ -44,7 +44,8 @@ COPY --from=go-builder /opt/app-root/plugin-backend /opt/app-root
 ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist"]
 
 LABEL com.redhat.component="coo-distributed-tracing-console-plugin" \
-      name="openshift/distributed-tracing-console-plugin" \
+      name="cluster-observability-operator/distributed-tracing-console-plugin-0-3-rhel9" \
+      cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
       version="v0.3.0" \
       summary="OpenShift console plugin to view and explore traces" \
       io.openshift.tags="openshift,observability-ui,distributed tracing" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
