### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for korrel8r-1-2

### DIFF
--- a/Dockerfile.korrel8r
+++ b/Dockerfile.korrel8r
@@ -21,9 +21,10 @@ USER 1000
 ENTRYPOINT [ "/bin/korrel8r", "web" ]
 
 LABEL com.redhat.component="coo-korrel8r-container" \
-      name="rhobs/korrel8r" \
+      name="cluster-observability-operator/korrel8r-rhel9" \
       version="release-coo-1.2" \
       summary="Korrel8r for Cluster Observability Operator" \
+      cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
       io.openshift.expose-services="" \
       io.openshift.tags="monitoring" \
       io.k8s.display-name="COO Korrel8r" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
