### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for logging-console-plugin-6-0-1-2

### DIFF
--- a/Dockerfile.ui-logging-pf4
+++ b/Dockerfile.ui-logging-pf4
@@ -45,7 +45,8 @@ COPY ui-logging-pf4/config /opt/app-root/config
 ENTRYPOINT ["/opt/app-root/plugin-backend", "-config-path", "/opt/app-root/config", "-static-path", "/opt/app-root/web/dist"]
 
 LABEL com.redhat.component="coo-logging-console-plugin" \
-      name="openshift/logging-console-plugin" \
+      name="cluster-observability-operator/logging-console-plugin-6-0-rhel9" \
+      cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
       version="v6.0.0" \
       summary="OpenShift console plugin to view and explore logs" \
       io.openshift.tags="openshift,observability-ui,logging" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
