### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for monitoring-console-plugin-0-5-1-2

### DIFF
--- a/Dockerfile.ui-monitoring
+++ b/Dockerfile.ui-monitoring
@@ -51,7 +51,8 @@ COPY --from=web-builder /opt/app-root/config /opt/app-root/config
 ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist"]
 
 LABEL com.redhat.component="coo-monitoring-console-plugin" \
-      name="openshift/monitoring-console-plugin" \
+      name="cluster-observability-operator/monitoring-console-plugin-0-5-rhel9" \
+      cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
       version="v0.5.0" \
       summary="OpenShift monitoring plugin to view and explore metrics and alerts" \
       io.openshift.tags="openshift,observability-ui,metrics,alerts" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
