### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for obo-prometheus-operator-prometheus-config-reloader-1-2

### DIFF
--- a/Dockerfile.prometheus-config-reloader
+++ b/Dockerfile.prometheus-config-reloader
@@ -20,7 +20,8 @@ USER nobody
 ENTRYPOINT ["/bin/prometheus-config-reloader"]
 
 LABEL com.redhat.component="coo-po-prometheus-config-reloader" \
-      name="prometheus-operator-prometheus-config-reloader" \
+      name="cluster-observability-operator/obo-prometheus-operator-prometheus-config-reloader-rhel9" \
+      cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
       version="v0.80.1" \
       summary="Prometheus Config Reloader for Prometheus Operator" \
       io.openshift.tags="monitoring" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
