### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for obo-prometheus-operator-1-2

### DIFF
--- a/Dockerfile.prom-op
+++ b/Dockerfile.prom-op
@@ -18,7 +18,8 @@ COPY --from=builder /workspace/LICENSE      /licenses/.
 USER 65534
 
 LABEL com.redhat.component="coo-prometheus-operator" \
-      name="prometheus-operator" \
+      name="cluster-observability-operator/obo-prometheus-rhel9-operator" \
+      cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
       version="v0.80.1" \
       summary="Prometheus Operator" \
       io.openshift.tags="monitoring" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
