### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for perses-operator-0-1-1-2

### DIFF
--- a/Dockerfile.perses-operator
+++ b/Dockerfile.perses-operator
@@ -26,9 +26,10 @@ EXPOSE     8080
 ENTRYPOINT [ "/bin/manager" ]
 
 LABEL com.redhat.component="coo-perses-operator" \
-    name="perses/perses-operator" \
+    name="cluster-observability-operator/perses-0-1-rhel9-operator" \
     version="v0.1.12" \
     summary="Perses Operator for Cluster Observability Operator" \
+    cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
     io.openshift.tags="openshift,observability-ui,perses-operator" \
     io.k8s.display-name="Perses Operator for Cluster Observability Operator" \
     io.k8s.description="Perses Operator for Cluster Observability Operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
