### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for perses-0-50-1-2

### DIFF
--- a/Dockerfile.perses
+++ b/Dockerfile.perses
@@ -40,7 +40,8 @@ ENTRYPOINT [ "/bin/perses" ]
 CMD        ["--config=/etc/perses/config.yaml", "--log.level=error"]
 
 LABEL com.redhat.component="coo-perses" \
-    name="perses/perses" \
+    name="cluster-observability-operator/perses-0-50-rhel9" \
+    cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
     version="v0.51.1" \
     summary="Perses for Cluster Observability Operator" \
     io.openshift.tags="openshift,observability-ui,perses" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
