### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for prometheus-1-2

### DIFF
--- a/Dockerfile.prometheus
+++ b/Dockerfile.prometheus
@@ -43,8 +43,9 @@ CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
              "--storage.tsdb.path=/prometheus" ]
 
 LABEL com.redhat.component="coo-prometheus-container" \
-      name="prometheus/prometheus" \
+      name="cluster-observability-operator/prometheus-rhel9" \
       version="v3.2.1" \
+      cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
       summary="Prometheus for Cluster Observability Operator" \
       io.openshift.expose-services="" \
       io.openshift.tags="monitoring" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
