### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for thanos-1-2

### DIFF
--- a/Dockerfile.thanos
+++ b/Dockerfile.thanos
@@ -20,9 +20,10 @@ USER nobody
 ENTRYPOINT [ "/bin/thanos" ]
 
 LABEL com.redhat.component="coo-thanos-container" \
-      name="rhobs/thanos" \
+      name="cluster-observability-operator/thanos-rhel9" \
       version="v0.37.2" \
       summary="Thanos for Cluster Observability Operator" \
+      cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
       io.openshift.expose-services="" \
       io.openshift.tags="monitoring" \
       io.k8s.display-name="COO Thanos" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
