### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for troubleshooting-panel-console-plugin-0-4-1-2

### DIFF
--- a/Dockerfile.ui-troubleshooting-panel
+++ b/Dockerfile.ui-troubleshooting-panel
@@ -44,7 +44,8 @@ COPY --from=go-builder /opt/app-root/plugin-backend /opt/app-root
 ENTRYPOINT ["/opt/app-root/plugin-backend", "-static-path", "/opt/app-root/web/dist"]
 
 LABEL com.redhat.component="coo-troubleshooting-panel-console-plugin" \
-      name="openshift/troubleshooting-panel-console-plugin" \
+      name="cluster-observability-operator/troubleshooting-panel-console-plugin-0-4-rhel9" \
+      cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
       version="v0.4.0" \
       summary="OpenShift console plugin to troubleshoot by correlating observability signals" \
       io.openshift.tags="openshift,observability-ui,korrel8r,correlation" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
