### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cluster-health-analyzer-1-2

### DIFF
--- a/Dockerfile.cluster-health-analyzer
+++ b/Dockerfile.cluster-health-analyzer
@@ -26,7 +26,8 @@ USER 65532:65532
 ENTRYPOINT ["/bin/cluster-health-analyzer"]
 
 LABEL com.redhat.component="coo-cluster-health-analyzer" \
-      name="openshift/cluster-health-analyzer" \
+      name="cluster-observability-operator/cluster-health-analyzer-rhel9" \
+      cpe="cpe:/a:redhat:cluster_observability_operator:1.2::el9" \
       version="v0.5.1" \
       summary="OpenShift Cluster Health Analyzer" \
       io.openshift.tags="openshift,observability,metrics,alerts,incidents" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
