### PR TITLE
fix: ignore empty-values rule for .tekton files (#1597)

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -12,7 +12,10 @@ rules:
   document-end: disable
   document-start: disable
   empty-lines: enable
-  empty-values: enable
+  empty-values:
+    ignore: |
+       .tekton/*.yaml
+       .tekton/*.yml
   hyphens: enable
   key-duplicates: enable
   key-ordering: disable


### PR DESCRIPTION
* fix: ignore empty-values rule for .tekton files

Allow empty values in block mappings for .tekton YAML files to resolve lint failures on creationTimestamp and similar Kubernetes fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

* render_templates: fix typos and pass `make verify`

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

---------

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>
(cherry picked from commit e93559b9ed0fe5669b6e57270197ec6620debd11)

 Conflicts:
	bundle-patches/render_templates
        keep the state in HEAD