### PR TITLE
Add hermetic and prefetch-input settings

### DIFF
--- a/.tekton/alertmanager-1-3-pull-request.yaml
+++ b/.tekton/alertmanager-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./alertmanager"}, {"type": "npm", "path":"./alertmanager/ui/react-app"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/alertmanager-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/alertmanager-1-3-push.yaml
+++ b/.tekton/alertmanager-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./alertmanager"}, {"type": "npm", "path":"./alertmanager/ui/react-app"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/alertmanager-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/cluster-health-analyzer-1-3-pull-request.yaml
+++ b/.tekton/cluster-health-analyzer-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./cluster-health-analyzer"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/cluster-health-analyzer-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/cluster-health-analyzer-1-3-push.yaml
+++ b/.tekton/cluster-health-analyzer-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./cluster-health-analyzer"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/cluster-health-analyzer-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/cluster-observability-operator-1-3-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./observability-operator"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/cluster-observability-rhel9-operator:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/cluster-observability-operator-1-3-push.yaml
+++ b/.tekton/cluster-observability-operator-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./observability-operator"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/cluster-observability-rhel9-operator:{{revision}}
     - name: build-platforms

--- a/.tekton/cluster-observability-operator-bundle-1-3-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-bundle-1-3-pull-request.yaml
@@ -28,6 +28,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "rpm", "path": "./bundle-patches"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/cluster-observability-operator-bundle:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/cluster-observability-operator-bundle-1-3-push.yaml
+++ b/.tekton/cluster-observability-operator-bundle-1-3-push.yaml
@@ -28,6 +28,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "rpm", "path": "./bundle-patches"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/cluster-observability-operator-bundle:{{revision}}
     - name: dockerfile

--- a/.tekton/dashboards-console-plugin-1-3-pull-request.yaml
+++ b/.tekton/dashboards-console-plugin-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-dashboards"}, {"type": "npm", "path": "./ui-dashboards/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/dashboards-console-plugin-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/dashboards-console-plugin-1-3-push.yaml
+++ b/.tekton/dashboards-console-plugin-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-dashboards"}, {"type": "npm", "path": "./ui-dashboards/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/dashboards-console-plugin-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/distributed-tracing-console-plugin-1-3-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-distributed-tracing-pf4"}, {"type": "npm", "path": "./ui-distributed-tracing-pf4/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/distributed-tracing-console-plugin-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/distributed-tracing-console-plugin-1-3-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-distributed-tracing-pf4"}, {"type": "npm", "path": "./ui-distributed-tracing-pf4/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/distributed-tracing-console-plugin-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/distributed-tracing-console-plugin-pf4-1-3-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf4-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-distributed-tracing-pf4"}, {"type": "npm", "path": "./ui-distributed-tracing-pf4/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/distributed-tracing-console-plugin-pf4-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/distributed-tracing-console-plugin-pf4-1-3-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf4-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-distributed-tracing-pf4"}, {"type": "npm", "path": "./ui-distributed-tracing-pf4/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/distributed-tracing-console-plugin-pf4-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/distributed-tracing-console-plugin-pf5-1-3-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf5-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-distributed-tracing-pf5"}, {"type": "npm", "path": "./ui-distributed-tracing-pf5/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/distributed-tracing-console-plugin-pf5-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/distributed-tracing-console-plugin-pf5-1-3-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf5-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-distributed-tracing-pf5"}, {"type": "npm", "path": "./ui-distributed-tracing-pf5/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/distributed-tracing-console-plugin-pf5-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/korrel8r-1-3-pull-request.yaml
+++ b/.tekton/korrel8r-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./korrel8r"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/korrel8r-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/korrel8r-1-3-push.yaml
+++ b/.tekton/korrel8r-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./korrel8r"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/korrel8r-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/logging-console-plugin-1-3-pull-request.yaml
+++ b/.tekton/logging-console-plugin-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-logging-pf4"}, {"type": "npm", "path": "./ui-logging-pf4/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/logging-console-plugin-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/logging-console-plugin-1-3-push.yaml
+++ b/.tekton/logging-console-plugin-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-logging-pf4"}, {"type": "npm", "path": "./ui-logging-pf4/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/logging-console-plugin-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/logging-console-plugin-pf4-1-3-pull-request.yaml
+++ b/.tekton/logging-console-plugin-pf4-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-logging-pf4"}, {"type": "npm", "path": "./ui-logging-pf4/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/logging-console-plugin-pf4-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/logging-console-plugin-pf4-1-3-push.yaml
+++ b/.tekton/logging-console-plugin-pf4-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-logging-pf4"}, {"type": "npm", "path": "./ui-logging-pf4/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/logging-console-plugin-pf4-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/monitoring-console-plugin-1-3-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-monitoring-pf5"}, {"type": "npm", "path": "./ui-monitoring-pf5/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/monitoring-console-plugin-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/monitoring-console-plugin-1-3-push.yaml
+++ b/.tekton/monitoring-console-plugin-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-monitoring-pf5"}, {"type": "npm", "path": "./ui-monitoring-pf5/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/monitoring-console-plugin-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/monitoring-console-plugin-pf5-1-3-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-pf5-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-monitoring-pf5"}, {"type": "npm", "path": "./ui-monitoring-pf5/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/monitoring-console-plugin-pf5-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/monitoring-console-plugin-pf5-1-3-push.yaml
+++ b/.tekton/monitoring-console-plugin-pf5-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-monitoring-pf5"}, {"type": "npm", "path": "./ui-monitoring-pf5/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/monitoring-console-plugin-pf5-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/obo-prometheus-operator-1-3-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./obo-prometheus-operator"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/obo-prometheus-rhel9-operator:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/obo-prometheus-operator-1-3-push.yaml
+++ b/.tekton/obo-prometheus-operator-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./obo-prometheus-operator"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/obo-prometheus-rhel9-operator:{{revision}}
     - name: build-platforms

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-3-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./obo-prometheus-operator"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/obo-prometheus-operator-admission-webhook-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-3-push.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./obo-prometheus-operator"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/obo-prometheus-operator-admission-webhook-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-3-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./obo-prometheus-operator"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/obo-prometheus-operator-prometheus-config-reloader-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-3-push.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./obo-prometheus-operator"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/obo-prometheus-operator-prometheus-config-reloader-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/perses-1-3-pull-request.yaml
+++ b/.tekton/perses-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./perses"}, {"type": "rpm"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/perses-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/perses-1-3-push.yaml
+++ b/.tekton/perses-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./perses"}, {"type": "rpm"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/perses-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/perses-operator-1-3-pull-request.yaml
+++ b/.tekton/perses-operator-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./perses-operator"}, {"type": "rpm"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/perses-rhel9-operator:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/perses-operator-1-3-push.yaml
+++ b/.tekton/perses-operator-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./perses-operator"}, {"type": "rpm"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/perses-rhel9-operator:{{revision}}
     - name: build-platforms

--- a/.tekton/prometheus-1-3-pull-request.yaml
+++ b/.tekton/prometheus-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./prometheus"}, {"type": "npm", "path": "./prometheus/web/ui"}, {"type": "npm", "path": "./prometheus/web/ui/react-app"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/prometheus-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/prometheus-1-3-push.yaml
+++ b/.tekton/prometheus-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./prometheus"}, {"type": "npm", "path": "./prometheus/web/ui"}, {"type": "npm", "path": "./prometheus/web/ui/react-app"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/prometheus-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/thanos-1-3-pull-request.yaml
+++ b/.tekton/thanos-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./thanos"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/thanos-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/thanos-1-3-push.yaml
+++ b/.tekton/thanos-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./thanos"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/thanos-rhel9:{{revision}}
     - name: build-platforms

--- a/.tekton/troubleshooting-panel-console-plugin-1-3-pull-request.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-1-3-pull-request.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-troubleshooting-panel"}, {"type": "npm", "path": "./ui-troubleshooting-panel/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/troubleshooting-panel-console-plugin-rhel9:on-pr-{{revision}}
     - name: image-expires-after

--- a/.tekton/troubleshooting-panel-console-plugin-1-3-push.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-1-3-push.yaml
@@ -27,6 +27,10 @@ spec:
       value: '{{source_url}}'
     - name: revision
       value: '{{revision}}'
+    - name: prefetch-input
+      value: [{"type": "gomod", "path": "./ui-troubleshooting-panel"}, {"type": "npm", "path": "./ui-troubleshooting-panel/web"}]
+    - name: hermetic
+      value: "true"
     - name: output-image
       value: quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/troubleshooting-panel-console-plugin-rhel9:{{revision}}
     - name: build-platforms


### PR DESCRIPTION
This commit adds both hermetic and prefetch-input settings to every
konflux pipeline for the COO components. This ensures that no go.mod
dependencies are tried to be pulled off when running in a disconnected
environment.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>
