### PR TITLE
COO-1267: Set default buildah-format to oci but override to docker

### DIFF
--- a/.tekton/alertmanager-1-3-pull-request.yaml
+++ b/.tekton/alertmanager-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -113,10 +115,10 @@ spec:
         description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
         name: build-platforms
         type: array
-      - name: buildah-format
-        default: docker
-        type: string
+      - default: oci
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
+        name: buildah-format
+        type: string
     results:
       - description: ""
         name: IMAGE_URL

--- a/.tekton/cluster-health-analyzer-1-3-pull-request.yaml
+++ b/.tekton/cluster-health-analyzer-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,7 +116,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/cluster-health-analyzer-1-3-push.yaml
+++ b/.tekton/cluster-health-analyzer-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -112,7 +114,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/cluster-observability-operator-1-3-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,7 +116,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/cluster-observability-operator-1-3-push.yaml
+++ b/.tekton/cluster-observability-operator-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -112,7 +114,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/cluster-observability-operator-bundle-1-3-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-bundle-1-3-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -127,7 +129,7 @@ spec:
         name: privileged-nested
         type: string
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/cluster-observability-operator-bundle-1-3-push.yaml
+++ b/.tekton/cluster-observability-operator-bundle-1-3-push.yaml
@@ -39,6 +39,8 @@ spec:
         - REGISTRY=registry.redhat.io
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -128,7 +130,7 @@ spec:
         name: privileged-nested
         type: string
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/dashboards-console-plugin-1-3-pull-request.yaml
+++ b/.tekton/dashboards-console-plugin-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/dashboards-console-plugin-1-3-push.yaml
+++ b/.tekton/dashboards-console-plugin-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/distributed-tracing-console-plugin-1-3-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,7 +116,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/distributed-tracing-console-plugin-1-3-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -112,7 +114,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/distributed-tracing-console-plugin-pf4-1-3-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf4-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,7 +116,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/distributed-tracing-console-plugin-pf4-1-3-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf4-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -112,7 +114,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/distributed-tracing-console-plugin-pf5-1-3-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf5-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,7 +116,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/distributed-tracing-console-plugin-pf5-1-3-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf5-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -112,7 +114,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/korrel8r-1-3-pull-request.yaml
+++ b/.tekton/korrel8r-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,7 +116,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/korrel8r-1-3-push.yaml
+++ b/.tekton/korrel8r-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -112,7 +114,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/logging-console-plugin-1-3-pull-request.yaml
+++ b/.tekton/logging-console-plugin-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/logging-console-plugin-1-3-push.yaml
+++ b/.tekton/logging-console-plugin-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/logging-console-plugin-pf4-1-3-pull-request.yaml
+++ b/.tekton/logging-console-plugin-pf4-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/logging-console-plugin-pf4-1-3-push.yaml
+++ b/.tekton/logging-console-plugin-pf4-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/monitoring-console-plugin-1-3-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,7 +116,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/monitoring-console-plugin-1-3-push.yaml
+++ b/.tekton/monitoring-console-plugin-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -112,7 +114,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/monitoring-console-plugin-pf5-1-3-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-pf5-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/monitoring-console-plugin-pf5-1-3-push.yaml
+++ b/.tekton/monitoring-console-plugin-pf5-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/obo-prometheus-operator-1-3-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,7 +116,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/obo-prometheus-operator-1-3-push.yaml
+++ b/.tekton/obo-prometheus-operator-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -112,7 +114,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-3-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,7 +116,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-3-push.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -112,7 +114,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-3-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,7 +116,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-3-push.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -112,7 +114,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/perses-1-3-pull-request.yaml
+++ b/.tekton/perses-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-1-3-push.yaml
+++ b/.tekton/perses-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-operator-1-3-pull-request.yaml
+++ b/.tekton/perses-operator-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/perses-operator-1-3-push.yaml
+++ b/.tekton/perses-operator-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/prometheus-1-3-pull-request.yaml
+++ b/.tekton/prometheus-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,7 +116,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/prometheus-1-3-push.yaml
+++ b/.tekton/prometheus-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -112,7 +114,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/thanos-1-3-pull-request.yaml
+++ b/.tekton/thanos-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,7 +116,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/thanos-1-3-push.yaml
+++ b/.tekton/thanos-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -112,7 +114,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/troubleshooting-panel-console-plugin-1-3-pull-request.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-1-3-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -114,7 +116,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:

--- a/.tekton/troubleshooting-panel-console-plugin-1-3-push.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-1-3-push.yaml
@@ -41,6 +41,8 @@ spec:
       value: .
     - name: build-source-image
       value: "true"
+    - name: buildah-format
+      value: docker
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -112,7 +114,7 @@ spec:
         name: build-platforms
         type: array
       - name: buildah-format
-        default: docker
+        default: oci
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
     results:


### PR DESCRIPTION
This commit sets the default buildah-format to oci, but overrides it to
docker for all the COO pipelines.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>