### PR TITLE
chore(deps): update korrel8r digest to fc556c9 and update Dockerfile

### DIFF
--- a/Dockerfile.korrel8r
+++ b/Dockerfile.korrel8r
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
This commit updates korrel8r submodule and bumps the golang builder to
use go 1.24

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>