### PR TITLE
Remove build compute resources

### DIFF
--- a/.tekton/prometheus-1-3-pull-request.yaml
+++ b/.tekton/prometheus-1-3-pull-request.yaml
@@ -49,15 +49,6 @@ spec:
       value: "true"
     - name: prefetch-input
       value: '[{"type": "gomod", "path": "./prometheus"}, {"type": "npm", "path": "./prometheus/web/ui"}, {"type": "npm", "path": "./prometheus/web/ui/react-app"}]'
-  taskRunSpecs:
-  - pipelineTaskName: build-images
-    stepSpecs:
-    - name: build
-      computeResources:
-        requests:
-          memory: 36Gi
-        limits:
-          memory: 50Gi
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/prometheus-1-3-push.yaml
+++ b/.tekton/prometheus-1-3-push.yaml
@@ -47,15 +47,6 @@ spec:
       value: "true"
     - name: prefetch-input
       value: '[{"type": "gomod", "path": "./prometheus"}, {"type": "npm", "path": "./prometheus/web/ui"}, {"type": "npm", "path": "./prometheus/web/ui/react-app"}]'
-  taskRunSpecs:
-  - pipelineTaskName: build-images
-    stepSpecs:
-    - name: build
-      computeResources:
-        requests:
-          memory: 36Gi
-        limits:
-          memory: 50Gi
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
When using multiarch, vms are now used instead of the cluster. This
commit removes the legacy configuration in order to avoid that
the pods for the tekton pipelines can't be allocated due to insufficient
memory.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>
