### PR TITLE
Enable FIPS compliance enforcement for prometheus-operator build

### DIFF
--- a/Dockerfile.prom-op
+++ b/Dockerfile.prom-op
@@ -5,7 +5,10 @@ WORKDIR /workspace
 COPY obo-prometheus-operator/ .
 
 ENV GOFLAGS='-mod=mod'
+
+ENV GOTOOLCHAIN=local
 ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
 
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -o operator ./cmd/operator/
 


### PR DESCRIPTION
Explicitly set needed ENVs for FIPS  to enable the Go compliance shim in
 openshift-golang-builder. This also bypasses the shim to use the real
go implementation

This ensures:

- CGO_ENABLED=1 (dynamic linking to OpenSSL)
- GOEXPERIMENT=strictfipsruntime automatically added
- GOTOOLCHAIN=local use the container's FIPS-patched Go, prevent
  downloading upstream toolchain

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>
