### PR TITLE
COO-1682: fix: set proper non root permissions to perses image

### DIFF
--- a/Dockerfile.perses
+++ b/Dockerfile.perses
@@ -32,7 +32,13 @@ COPY --from=builder  /etc/mime.types                         /etc/mime.types
 RUN chgrp -R 0 /etc/perses && \
     chmod -R g=u /etc/perses
 
+RUN mkdir -p /perses && \
+    chgrp -R 0 /perses && \
+    chmod -R g=u /perses
+
 WORKDIR /perses
+
+USER 65534
 
 EXPOSE     8080
 VOLUME     ["/perses"]


### PR DESCRIPTION
Set the user and right permissions for Perses folders to avoid security issues