### PR TITLE
revert-dockerfile-push-update

### DIFF
--- a/.tekton/alertmanager-1-4-pull-request.yaml
+++ b/.tekton/alertmanager-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/alertmanager-1-4-push.yaml
+++ b/.tekton/alertmanager-1-4-push.yaml
@@ -575,7 +575,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/cluster-health-analyzer-1-4-pull-request.yaml
+++ b/.tekton/cluster-health-analyzer-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/cluster-health-analyzer-1-4-push.yaml
+++ b/.tekton/cluster-health-analyzer-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/cluster-observability-operator-1-4-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/cluster-observability-operator-1-4-push.yaml
+++ b/.tekton/cluster-observability-operator-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/dashboards-console-plugin-1-4-pull-request.yaml
+++ b/.tekton/dashboards-console-plugin-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/dashboards-console-plugin-1-4-push.yaml
+++ b/.tekton/dashboards-console-plugin-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/distributed-tracing-console-plugin-1-4-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/distributed-tracing-console-plugin-1-4-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/distributed-tracing-console-plugin-pf4-1-4-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf4-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/distributed-tracing-console-plugin-pf4-1-4-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf4-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/distributed-tracing-console-plugin-pf5-1-4-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf5-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/distributed-tracing-console-plugin-pf5-1-4-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf5-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/korrel8r-1-4-pull-request.yaml
+++ b/.tekton/korrel8r-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/korrel8r-1-4-push.yaml
+++ b/.tekton/korrel8r-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/logging-console-plugin-1-4-pull-request.yaml
+++ b/.tekton/logging-console-plugin-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/logging-console-plugin-1-4-push.yaml
+++ b/.tekton/logging-console-plugin-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/logging-console-plugin-pf4-1-4-pull-request.yaml
+++ b/.tekton/logging-console-plugin-pf4-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/logging-console-plugin-pf4-1-4-push.yaml
+++ b/.tekton/logging-console-plugin-pf4-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/monitoring-console-plugin-1-4-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/monitoring-console-plugin-1-4-push.yaml
+++ b/.tekton/monitoring-console-plugin-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/monitoring-console-plugin-pf5-1-4-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-pf5-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/monitoring-console-plugin-pf5-1-4-push.yaml
+++ b/.tekton/monitoring-console-plugin-pf5-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/obo-prometheus-operator-1-4-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/obo-prometheus-operator-1-4-push.yaml
+++ b/.tekton/obo-prometheus-operator-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-4-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-4-push.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-push.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/perses-1-4-pull-request.yaml
+++ b/.tekton/perses-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/perses-1-4-push.yaml
+++ b/.tekton/perses-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/perses-operator-1-4-pull-request.yaml
+++ b/.tekton/perses-operator-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/perses-operator-1-4-push.yaml
+++ b/.tekton/perses-operator-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/prometheus-1-4-pull-request.yaml
+++ b/.tekton/prometheus-1-4-pull-request.yaml
@@ -594,7 +594,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/prometheus-1-4-push.yaml
+++ b/.tekton/prometheus-1-4-push.yaml
@@ -592,7 +592,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/thanos-1-4-pull-request.yaml
+++ b/.tekton/thanos-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/thanos-1-4-push.yaml
+++ b/.tekton/thanos-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/troubleshooting-panel-console-plugin-1-4-pull-request.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-1-4-pull-request.yaml
@@ -585,7 +585,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/troubleshooting-panel-console-plugin-1-4-push.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-1-4-push.yaml
@@ -581,7 +581,7 @@ spec:
             - name: name
               value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:322d515ca66d92188067344761733d1e5c64d4b7bb790d10f35540da5e6289f1
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.2@sha256:efda2b60a3e6f1e1f64150963f4133f2f6353f8fcf9db86768466bf3f2753277
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
New version of `push-dockerfile-oci-ta` task expects dockerfile to be exactly the string `Dockerfile` and not anything else

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1772636735955199