### PR TITLE
alertmanager: track tag v0.31.0 is submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "alertmanager"]
 	path = alertmanager
 	url = https://github.com/prometheus/alertmanager
+	branch = v0.31.0 # git submodules can't handle tags, but renovate can
 [submodule "prometheus"]
 	path = prometheus
 	url = https://github.com/prometheus/prometheus.git


### PR DESCRIPTION
This works only for renovate. the `git submodule` commands will error on this since it can't find the branch. This means alertmanager needs manually updating as long as we track the tag.