### PR TITLE
COO-1733: feat(.tekton): add slack failure notifications to push pipelines

### DIFF
--- a/.tekton/alertmanager-1-4-push.yaml
+++ b/.tekton/alertmanager-1-4-push.yaml
@@ -615,6 +615,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/cluster-health-analyzer-1-4-push.yaml
+++ b/.tekton/cluster-health-analyzer-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/cluster-observability-operator-1-4-push.yaml
+++ b/.tekton/cluster-observability-operator-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/cluster-observability-operator-bundle-1-4-push.yaml
+++ b/.tekton/cluster-observability-operator-bundle-1-4-push.yaml
@@ -567,6 +567,29 @@ spec:
             operator: in
             values:
               - "false"
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: workspace
       - name: git-auth

--- a/.tekton/dashboards-console-plugin-1-4-push.yaml
+++ b/.tekton/dashboards-console-plugin-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/distributed-tracing-console-plugin-1-4-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/distributed-tracing-console-plugin-pf4-1-4-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf4-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/distributed-tracing-console-plugin-pf5-1-4-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf5-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/korrel8r-1-4-push.yaml
+++ b/.tekton/korrel8r-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/logging-console-plugin-1-4-push.yaml
+++ b/.tekton/logging-console-plugin-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/logging-console-plugin-pf4-1-4-push.yaml
+++ b/.tekton/logging-console-plugin-pf4-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/monitoring-console-plugin-1-4-push.yaml
+++ b/.tekton/monitoring-console-plugin-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/monitoring-console-plugin-pf5-1-4-push.yaml
+++ b/.tekton/monitoring-console-plugin-pf5-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/obo-prometheus-operator-1-4-push.yaml
+++ b/.tekton/obo-prometheus-operator-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-4-push.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-push.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/perses-1-4-push.yaml
+++ b/.tekton/perses-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/perses-operator-1-4-push.yaml
+++ b/.tekton/perses-operator-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/prometheus-1-4-push.yaml
+++ b/.tekton/prometheus-1-4-push.yaml
@@ -632,6 +632,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/thanos-1-4-push.yaml
+++ b/.tekton/thanos-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/.tekton/troubleshooting-panel-console-plugin-1-4-push.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-1-4-push.yaml
@@ -621,6 +621,29 @@ spec:
           - clone-repository
         taskRef:
           name: get-submodule-commit-labels
+    finally:
+      - name: slack-webhook-notification
+        params:
+          - name: message
+            value: PipelineRun $(context.pipelineRun.name) failed
+          - name: secret-name
+            value: slack-notifications
+          - name: key-name
+            value: obo-cicd
+        taskRef:
+          params:
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+            - name: name
+              value: slack-webhook-notification
+            - name: kind
+              value: Task
+          resolver: bundles
+        when:
+          - input: $(tasks.status)
+            operator: in
+            values:
+              - Failed
     workspaces:
       - name: git-auth
         optional: true

--- a/hack/customize-pipeline.sh
+++ b/hack/customize-pipeline.sh
@@ -37,6 +37,35 @@ add_submodule_tasks() {
     fi
 }
 
+add_slack_notification() {
+    local file="$1"
+
+    # Check if slack-webhook-notification task already exists in finally block
+    if ! yq '.spec.pipelineSpec.finally[]? | select(.name == "slack-webhook-notification")' "$file" | grep -q "slack-webhook-notification"; then
+        yq -i '
+            .spec.pipelineSpec.finally += [{
+                "name": "slack-webhook-notification",
+                "params": [
+                    {"name": "message", "value": "PipelineRun $(context.pipelineRun.name) failed"},
+                    {"name": "secret-name", "value": "slack-notifications"},
+                    {"name": "key-name", "value": "obo-cicd"}
+                ],
+                "taskRef": {
+                    "params": [
+                        {"name": "bundle", "value": "quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1"},
+                        {"name": "name", "value": "slack-webhook-notification"},
+                        {"name": "kind", "value": "Task"}
+                    ],
+                    "resolver": "bundles"
+                },
+                "when": [
+                    {"input": "$(tasks.status)", "operator": "in", "values": ["Failed"]}
+                ]
+            }]
+        ' "$file"
+    fi
+}
+
 for file in "$@"
 do
     echo "Processing file $file"
@@ -67,6 +96,9 @@ do
         fi
 
         add_submodule_tasks "$file"
+    fi
+    if [[ $action == "push" ]]; then
+        add_slack_notification "$file"
     fi
     yq -i '.metadata.annotations += {"pipelinesascode.tekton.dev/on-cel-expression": strenv(trigger)}' "$file"
     yq -i '(.spec.params[] | select(.name == "build-platforms").value | select(length == 1)) += ["linux/arm64","linux/ppc64le","linux/s390x"]' "$file"


### PR DESCRIPTION
Add slack-webhook-notification task in the finally block of all push pipelines. The task sends a Slack message when the pipeline fails, using the slack-notifications secret (key: obo-cicd).