### PR TITLE
Revert "Update quay.io/konflux-ci/buildah-task Docker tag to v2296080 (#2846)"

### DIFF
--- a/.tekton/tasks/get-submodule-commit-labels.yaml
+++ b/.tekton/tasks/get-submodule-commit-labels.yaml
@@ -27,7 +27,7 @@ spec:
         - use
         - $(params.SOURCE-ARTIFACT)=/tekton/home/source
     - name: get-submodule-sha
-      image: quay.io/konflux-ci/buildah-task:2296080
+      image: quay.io/konflux-ci/buildah-task:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
       workingDir: /tekton/home/source
       script: |
         #!/bin/bash


### PR DESCRIPTION
This reverts commit ee811256aa30e4e0dd7c352e828544f7eaa85d0. which was
downgrading the buildah task, leading to CI outage due to lack of git
binary in the image.