### PR TITLE
renovate: remove latest renovate global config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,4 @@
 {
-    "extends": [
-        "github>konflux-ci/mintmaker//config/renovate/renovate.json"
-    ],
     "ignoreDeps": [
         "registry.redhat.io/openshift4/ose-operator-registry",
         "registry.redhat.io/openshift4/ose-operator-registry-rhel9"


### PR DESCRIPTION
This global config which is applied to all repositories by mintmaker, however this is the latest version
and it might cause some issues when the latest version has something incompatible with the current deployments.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>