### PR TITLE
build: enable strictfipsruntime and CGO for COO Go images

### DIFF
--- a/Dockerfile.alertmanager
+++ b/Dockerfile.alertmanager
@@ -5,8 +5,11 @@ WORKDIR /workspace
 COPY alertmanager/ .
 
 ENV GOFLAGS='-mod=mod -tags=netgo'
-ENV CGO_ENABLED=0
+ENV GOTOOLCHAIN=local
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
 ENV NO_DOCKER=true
+
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -o alertmanager github.com/prometheus/alertmanager/cmd/alertmanager
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -o amtool github.com/prometheus/alertmanager/cmd/amtool
 

--- a/Dockerfile.obo
+++ b/Dockerfile.obo
@@ -5,7 +5,9 @@ WORKDIR /workspace
 COPY observability-operator/ .
 
 ENV GOFLAGS='-mod=mod'
+ENV GOTOOLCHAIN=local
 ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
 
 # Build
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -tags netgo,osusergo -o manager cmd/operator/main.go

--- a/Dockerfile.p-o-admission-webhook
+++ b/Dockerfile.p-o-admission-webhook
@@ -5,14 +5,28 @@ WORKDIR /workspace
 COPY obo-prometheus-operator/ .
 
 ENV GOFLAGS='-mod=mod'
-ENV CGO_ENABLED=0
-
-# Build
-RUN make admission-webhook
+ENV GOTOOLCHAIN=local
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+# CGO required for FIPS/check-payload; upstream Makefile uses CGO_ENABLED=0 for this target — build here instead of touching the submodule Makefile.
+ARG TARGETOS TARGETARCH
+RUN VERSION="$(tr -d ' \t\n\r' < VERSION)" && \
+    BUILD_DATE="$(date +%Y%m%d-%T)" && \
+    BUILD_REVISION="$(git rev-parse --short HEAD 2>/dev/null || true)" && \
+    BUILD_USER="${BUILD_USER:-coo-image-build}" && \
+    BUILD_BRANCH="$(git branch --show-current 2>/dev/null || true)" && \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=1 go build -mod=mod \
+      -ldflags="-s \
+        -X github.com/prometheus/common/version.Revision=${BUILD_REVISION} \
+        -X github.com/prometheus/common/version.BuildUser=${BUILD_USER} \
+        -X github.com/prometheus/common/version.BuildDate=${BUILD_DATE} \
+        -X github.com/prometheus/common/version.Branch=${BUILD_BRANCH} \
+        -X github.com/prometheus/common/version.Version=${VERSION}" \
+      -o admission-webhook ./cmd/admission-webhook/
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
 
-COPY --from=builder workspace/admission-webhook /bin/admission-webhook
+COPY --from=builder /workspace/admission-webhook /bin/admission-webhook
 COPY --from=builder /workspace/LICENSE      /licenses/.
 
 USER nobody

--- a/Dockerfile.prometheus
+++ b/Dockerfile.prometheus
@@ -17,7 +17,9 @@ WORKDIR /workspace
 COPY --from=web-builder /workspace/ .
 
 ENV GOFLAGS='-mod=mod -tags=builtinassets,netgo,stringlabels'
-ENV CGO_ENABLED=0
+ENV GOTOOLCHAIN=local
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
 # Build prometheus directly using Go
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -o ./prometheus ./cmd/prometheus
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -o ./promtool ./cmd/promtool

--- a/Dockerfile.thanos
+++ b/Dockerfile.thanos
@@ -4,11 +4,16 @@ WORKDIR /workspace
 
 COPY thanos .
 
-ENV CGO_ENABLED=0
+ENV GOTOOLCHAIN=local
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
 
-# Install promu and build thanos
+# Konflux prepends: . /cachi2/cachi2.env && …
+# cachi2.env often sets GOFLAGS=-mod=mod, which makes the compiler expect module zips under the
+# prefetch cache (…/pkg/mod/cache/download/*.zip) that Thanos builds hit as missing. The submodule
+# ships vendor/; -mod=vendor avoids that. Pass -mod/-tags on the CLI so they override GOFLAGS.
 ARG TARGETOS TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags -netgo $GOFLAGS -o /go/bin/thanos ./cmd/thanos
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -mod=vendor -tags=netgo -o /go/bin/thanos ./cmd/thanos
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
 WORKDIR /

--- a/hack/analyze-xcrypto-fips.sh
+++ b/hack/analyze-xcrypto-fips.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Inventory golang.org/x/crypto reachability from git submodule roots (OCPSTRAT-1882 helper).
+# See internal doc: "OpenShift, x/crypto, FIPS 140" (+ check-payload PR216 / callgraph examples).
+#
+# Scans every path listed in .gitmodules that has a go.mod at the submodule root.
+# Main packages: all mains under ./cmd/... (if present) plus the module root if main.go exists.
+#
+# Optional: ANALYZE_XCRYPTO_INCLUDE_SLOW=1 runs full ./... main discovery when the fast path
+# finds no mains (can be very slow for large trees like prometheus).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+unset GOFLAGS
+
+list_submodule_paths() {
+  local f="${ROOT}/.gitmodules"
+  [[ -f "$f" ]] || {
+    echo "warning: no .gitmodules at ${ROOT}" >&2
+    return 0
+  }
+  awk '
+    /^[[:space:]]*path[[:space:]]*=[[:space:]]*/ {
+      sub(/^[[:space:]]*path[[:space:]]*=[[:space:]]*/, "")
+      gsub(/\r$/, "")
+      print
+    }
+  ' "$f"
+}
+
+# Print unique main import paths for module at $1 (absolute path to module root).
+discover_main_import_paths() {
+  local modroot="$1"
+  local -a acc=()
+  local line
+
+  # Use Name=="main" — modern "go list -f" no longer exposes .Main (see go list template errors).
+  local list_fmt='{{if eq .Name "main"}}{{.ImportPath}}{{end}}'
+
+  if [[ -d "${modroot}/cmd" ]]; then
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] && acc+=("${line}")
+    done < <(
+      (cd "${modroot}" && go list -e -f "${list_fmt}" ./cmd/... 2>/dev/null) || true
+    )
+  fi
+  if [[ -f "${modroot}/main.go" ]]; then
+    line=$(cd "${modroot}" && go list -e -f "${list_fmt}" . 2>/dev/null || true)
+    [[ -n "${line}" ]] && acc+=("${line}")
+  fi
+
+  if [[ ${#acc[@]} -eq 0 && "${ANALYZE_XCRYPTO_INCLUDE_SLOW:-}" == 1 ]]; then
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] && acc+=("${line}")
+    done < <(
+      (cd "${modroot}" && go list -e -f "${list_fmt}" ./... 2>/dev/null) || true
+    )
+  fi
+
+  printf '%s\n' "${acc[@]}" | grep -v '^$' | sort -u
+}
+
+run_why() {
+  local modroot="$1"
+  local pkg="$2"
+  local label="$3"
+  echo ""
+  echo "======== ${label} ========"
+  (cd "${modroot}" && go mod why -m golang.org/x/crypto "${pkg}" 2>/dev/null || true)
+}
+
+echo "# Submodule roots from .gitmodules with go.mod (unset GOFLAGS for broken empty-token envs)"
+echo "# go mod why -m golang.org/x/crypto  (one chain per main; there may be several importers)"
+
+mapfile -t SUBS < <(list_submodule_paths)
+ALL_CRYPTO_LINES=()
+
+for rel in "${SUBS[@]}"; do
+  mod="${ROOT}/${rel}"
+  if [[ ! -d "${mod}" ]]; then
+    echo ""
+    echo "======== SKIP ${rel} (path missing — git submodule init/update?) ========"
+    continue
+  fi
+  if [[ ! -f "${mod}/go.mod" ]]; then
+    echo ""
+    echo "======== SKIP ${rel} (no go.mod at submodule root) ========"
+    continue
+  fi
+
+  mapfile -t MAINS < <(discover_main_import_paths "${mod}")
+  if [[ ${#MAINS[@]} -eq 0 ]]; then
+    echo ""
+    echo "======== SKIP ${rel} (no main packages via ./cmd/... or root main.go; set ANALYZE_XCRYPTO_INCLUDE_SLOW=1 to try ./...) ========"
+    continue
+  fi
+
+  echo ""
+  echo "######################################################################"
+  echo "# MODULE ${rel} (${#MAINS[@]} main(s))"
+  echo "######################################################################"
+
+  for main_pkg in "${MAINS[@]}"; do
+    run_why "${mod}" "${main_pkg}" "${rel} ${main_pkg}"
+  done
+
+  echo ""
+  echo "======== golang.org/x/crypto/* in dep closure (${rel}) ========"
+  for main_pkg in "${MAINS[@]}"; do
+    echo ""
+    echo "--- ${main_pkg} ---"
+    mapfile -t crypto_pkg < <(
+      (cd "${mod}" && go list -deps "${main_pkg}" 2>/dev/null | grep '^golang.org/x/crypto' | sort -u || true)
+    )
+    if [[ ${#crypto_pkg[@]} -gt 0 ]]; then
+      printf '%s\n' "${crypto_pkg[@]}"
+      ALL_CRYPTO_LINES+=("${crypto_pkg[@]}")
+    fi
+  done
+done
+
+echo ""
+echo "======== Unique golang.org/x/crypto/* across all scanned mains ========"
+if [[ ${#ALL_CRYPTO_LINES[@]} -eq 0 ]]; then
+  echo "(none found, or no modules scanned)"
+else
+  printf '%s\n' "${ALL_CRYPTO_LINES[@]}" | sort -u
+fi
+
+echo ""
+echo "Optional (install tools once):"
+echo "  go install golang.org/x/tools/cmd/callgraph@latest"
+echo "  go install golang.org/x/tools/cmd/digraph@latest"
+echo "Example:"
+echo "  (cd prometheus && callgraph -format=digraph ./cmd/prometheus | digraph nodes | grep '^golang.org/x/crypto')"


### PR DESCRIPTION
Align Konflux Docker builds with Red Hat FIPS-oriented Go (OpenSSL-backed
crypto): set GOTOOLCHAIN=local, CGO_ENABLED=1, and GOEXPERIMENT=strictfipsruntime
on alertmanager, observability-operator, prometheus, and thanos builder
stages.

Admission webhook: build via explicit go build with CGO enabled instead of
the upstream Makefile recipe (CGO_ENABLED=0), so binaries pass
openshift/check-payload validation. Fix webhook binary COPY path.

Thanos: go build -mod=vendor -tags=netgo on the CLI so it overrides cachi2
GOFLAGS=-mod=mod and avoids missing module zip errors in hermetic prefetch.

hack/analyze-xcrypto-fips.sh: inventory golang.org/x/crypto reachability for
all git submodule roots with go.mod (OCPSTRAT-1882 helper).

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>