### PR TITLE
build: enable FIPS build settings for perses and prometheus-config-reloader

### DIFF
--- a/Dockerfile.perses
+++ b/Dockerfile.perses
@@ -10,12 +10,19 @@ WORKDIR /app
 COPY perses/ .
 
 ENV GOFLAGS="-mod=readonly"
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+
 RUN go mod download
 
 RUN mkdir /plugins
 
-RUN make build-api
-RUN make build-cli
+# Run generate steps (assets compression, plugin installation)
+RUN make generate
+
+# CGO required for FIPS/check-payload; upstream Makefile uses CGO_ENABLED=0 — build here instead
+RUN go build -tags strictfipsruntime -ldflags "-s -w" -o ./bin/perses ./cmd/perses
+RUN go build -tags strictfipsruntime -ldflags "-s -w" -o ./bin/percli ./cmd/percli
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
 

--- a/Dockerfile.perses-operator
+++ b/Dockerfile.perses-operator
@@ -10,7 +10,10 @@ WORKDIR /app
 
 COPY perses-operator/ .
 
-RUN make bin
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+
+RUN make bin BUILD_OPTS="-tags strictfipsruntime"
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
 

--- a/Dockerfile.prometheus-config-reloader
+++ b/Dockerfile.prometheus-config-reloader
@@ -5,10 +5,11 @@ WORKDIR /workspace
 COPY obo-prometheus-operator/ .
 
 ENV GOFLAGS='-mod=mod'
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
 
-# Build
-RUN make prometheus-config-reloader
+# CGO required for FIPS/check-payload; upstream Makefile uses CGO_ENABLED=0 — build here instead
+RUN go build -tags strictfipsruntime -ldflags "-s -w" -o prometheus-config-reloader ./cmd/prometheus-config-reloader
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
 


### PR DESCRIPTION
Add CGO_ENABLED=1, GOEXPERIMENT=strictfipsruntime, and -tags strictfipsruntime
to produce dynamically-linked binaries for FIPS 140 compliance.

Note: x/crypto usage (bcrypt, nacl, salsa20) requires upstream changes for
full FIPS compliance per OCPSTRAT-1882.

Related: OCPEXCEPT-29
Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>