### PR TITLE
build: enable FIPS build settings across all Go components

### DIFF
--- a/Dockerfile.alertmanager
+++ b/Dockerfile.alertmanager
@@ -5,8 +5,11 @@ WORKDIR /workspace
 COPY alertmanager/ .
 
 ENV GOFLAGS='-mod=mod -tags=netgo'
-ENV CGO_ENABLED=0
+ENV GOTOOLCHAIN=local
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
 ENV NO_DOCKER=true
+
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -o alertmanager github.com/prometheus/alertmanager/cmd/alertmanager
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -o amtool github.com/prometheus/alertmanager/cmd/amtool
 

--- a/Dockerfile.obo
+++ b/Dockerfile.obo
@@ -5,7 +5,9 @@ WORKDIR /workspace
 COPY observability-operator/ .
 
 ENV GOFLAGS='-mod=mod'
+ENV GOTOOLCHAIN=local
 ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
 
 # Build
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -tags netgo,osusergo -o manager cmd/operator/main.go

--- a/Dockerfile.p-o-admission-webhook
+++ b/Dockerfile.p-o-admission-webhook
@@ -5,14 +5,28 @@ WORKDIR /workspace
 COPY obo-prometheus-operator/ .
 
 ENV GOFLAGS='-mod=mod'
-ENV CGO_ENABLED=0
-
-# Build
-RUN make admission-webhook
+ENV GOTOOLCHAIN=local
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+# CGO required for FIPS/check-payload; upstream Makefile uses CGO_ENABLED=0 for this target — build here instead of touching the submodule Makefile.
+ARG TARGETOS TARGETARCH
+RUN VERSION="$(tr -d ' \t\n\r' < VERSION)" && \
+    BUILD_DATE="$(date +%Y%m%d-%T)" && \
+    BUILD_REVISION="$(git rev-parse --short HEAD 2>/dev/null || true)" && \
+    BUILD_USER="${BUILD_USER:-coo-image-build}" && \
+    BUILD_BRANCH="$(git branch --show-current 2>/dev/null || true)" && \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=1 go build -mod=mod \
+      -ldflags="-s \
+        -X github.com/prometheus/common/version.Revision=${BUILD_REVISION} \
+        -X github.com/prometheus/common/version.BuildUser=${BUILD_USER} \
+        -X github.com/prometheus/common/version.BuildDate=${BUILD_DATE} \
+        -X github.com/prometheus/common/version.Branch=${BUILD_BRANCH} \
+        -X github.com/prometheus/common/version.Version=${VERSION}" \
+      -o admission-webhook ./cmd/admission-webhook/
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
 
-COPY --from=builder workspace/admission-webhook /bin/admission-webhook
+COPY --from=builder /workspace/admission-webhook /bin/admission-webhook
 COPY --from=builder /workspace/LICENSE      /licenses/.
 
 USER nobody

--- a/Dockerfile.perses
+++ b/Dockerfile.perses
@@ -10,12 +10,19 @@ WORKDIR /app
 COPY perses/ .
 
 ENV GOFLAGS="-mod=readonly"
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+
 RUN go mod download
 
 RUN mkdir /plugins
 
-RUN make build-api
-RUN make build-cli
+# Run generate steps (assets compression, plugin installation)
+RUN make generate
+
+# CGO required for FIPS/check-payload; upstream Makefile uses CGO_ENABLED=0 — build here instead
+RUN go build -tags strictfipsruntime -ldflags "-s -w" -o ./bin/perses ./cmd/perses
+RUN go build -tags strictfipsruntime -ldflags "-s -w" -o ./bin/percli ./cmd/percli
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
 

--- a/Dockerfile.perses-operator
+++ b/Dockerfile.perses-operator
@@ -10,7 +10,10 @@ WORKDIR /app
 
 COPY perses-operator/ .
 
-RUN make bin
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
+
+RUN make bin BUILD_OPTS="-tags strictfipsruntime"
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
 

--- a/Dockerfile.prometheus
+++ b/Dockerfile.prometheus
@@ -17,7 +17,9 @@ WORKDIR /workspace
 COPY --from=web-builder /workspace/ .
 
 ENV GOFLAGS='-mod=mod -tags=builtinassets,netgo,stringlabels'
-ENV CGO_ENABLED=0
+ENV GOTOOLCHAIN=local
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
 # Build prometheus directly using Go
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -o ./prometheus ./cmd/prometheus
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -o ./promtool ./cmd/promtool

--- a/Dockerfile.prometheus-config-reloader
+++ b/Dockerfile.prometheus-config-reloader
@@ -5,10 +5,11 @@ WORKDIR /workspace
 COPY obo-prometheus-operator/ .
 
 ENV GOFLAGS='-mod=mod'
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
 
-# Build
-RUN make prometheus-config-reloader
+# CGO required for FIPS/check-payload; upstream Makefile uses CGO_ENABLED=0 — build here instead
+RUN go build -tags strictfipsruntime -ldflags "-s -w" -o prometheus-config-reloader ./cmd/prometheus-config-reloader
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
 

--- a/Dockerfile.thanos
+++ b/Dockerfile.thanos
@@ -4,11 +4,16 @@ WORKDIR /workspace
 
 COPY thanos .
 
-ENV CGO_ENABLED=0
+ENV GOTOOLCHAIN=local
+ENV CGO_ENABLED=1
+ENV GOEXPERIMENT=strictfipsruntime
 
-# Install promu and build thanos
+# Konflux prepends: . /cachi2/cachi2.env && …
+# cachi2.env often sets GOFLAGS=-mod=mod, which makes the compiler expect module zips under the
+# prefetch cache (…/pkg/mod/cache/download/*.zip) that Thanos builds hit as missing. The submodule
+# ships vendor/; -mod=vendor avoids that. Pass -mod/-tags on the CLI so they override GOFLAGS.
 ARG TARGETOS TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags -netgo $GOFLAGS -o /go/bin/thanos ./cmd/thanos
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -mod=vendor -tags=netgo -o /go/bin/thanos ./cmd/thanos
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
 WORKDIR /


### PR DESCRIPTION
Add CGO_ENABLED=1, GOEXPERIMENT=strictfipsruntime, GOTOOLCHAIN=local and
-tags strictfipsruntime to all Go component Dockerfiles to produce
dynamically-linked binaries for FIPS 140 compliance. Aligns with release-1.5.

Note: x/crypto usage (bcrypt, nacl, salsa20) still requires upstream
changes for full FIPS compliance per OCPSTRAT-1882.

Related: OCPEXCEPT-29
Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>