### PR TITLE
fix pipeline triggers

### DIFF
--- a/.tekton/alertmanager-1-4-pull-request.yaml
+++ b/.tekton/alertmanager-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/alertmanager-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/alertmanager-1-4-push.yaml".pathChanged() ||
               "Dockerfile.alertmanager".pathChanged() ||
               "alertmanager".pathChanged())
   creationTimestamp: null

--- a/.tekton/alertmanager-1-4-push.yaml
+++ b/.tekton/alertmanager-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/alertmanager-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/alertmanager-1-4-push.yaml".pathChanged() ||
               "Dockerfile.alertmanager".pathChanged() ||
               "alertmanager".pathChanged())

--- a/.tekton/cluster-health-analyzer-1-4-pull-request.yaml
+++ b/.tekton/cluster-health-analyzer-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/cluster-health-analyzer-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/cluster-health-analyzer-1-4-push.yaml".pathChanged() ||
               "Dockerfile.cluster-health-analyzer".pathChanged() ||
               "cluster-health-analyzer".pathChanged())
   creationTimestamp: null

--- a/.tekton/cluster-health-analyzer-1-4-push.yaml
+++ b/.tekton/cluster-health-analyzer-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/cluster-health-analyzer-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/cluster-health-analyzer-1-4-push.yaml".pathChanged() ||
               "Dockerfile.cluster-health-analyzer".pathChanged() ||
               "cluster-health-analyzer".pathChanged())

--- a/.tekton/cluster-observability-operator-1-4-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/cluster-observability-operator-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/cluster-observability-operator-1-4-push.yaml".pathChanged() ||
               "Dockerfile.obo".pathChanged() ||
               "observability-operator".pathChanged())
   creationTimestamp: null

--- a/.tekton/cluster-observability-operator-1-4-push.yaml
+++ b/.tekton/cluster-observability-operator-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/cluster-observability-operator-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/cluster-observability-operator-1-4-push.yaml".pathChanged() ||
               "Dockerfile.obo".pathChanged() ||
               "observability-operator".pathChanged())

--- a/.tekton/cluster-observability-operator-bundle-1-4-pull-request.yaml
+++ b/.tekton/cluster-observability-operator-bundle-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/cluster-observability-operator-bundle-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/cluster-observability-operator-bundle-1-4-push.yaml".pathChanged() ||
               "Dockerfile.bundle".pathChanged() ||
               "bundle-patches/***".pathChanged() ||
               "observability-operator/bundle/***".pathChanged())

--- a/.tekton/cluster-observability-operator-bundle-1-4-push.yaml
+++ b/.tekton/cluster-observability-operator-bundle-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/cluster-observability-operator-bundle-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/cluster-observability-operator-bundle-1-4-push.yaml".pathChanged() ||
               "Dockerfile.bundle".pathChanged() ||
               "bundle-patches/***".pathChanged() ||

--- a/.tekton/dashboards-console-plugin-1-4-pull-request.yaml
+++ b/.tekton/dashboards-console-plugin-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/dashboards-console-plugin-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/dashboards-console-plugin-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-dashboards".pathChanged() ||
               "ui-dashboards".pathChanged())
   creationTimestamp: null

--- a/.tekton/dashboards-console-plugin-1-4-push.yaml
+++ b/.tekton/dashboards-console-plugin-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/dashboards-console-plugin-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/dashboards-console-plugin-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-dashboards".pathChanged() ||
               "ui-dashboards".pathChanged())

--- a/.tekton/distributed-tracing-console-plugin-1-4-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/distributed-tracing-console-plugin-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/distributed-tracing-console-plugin-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-distributed-tracing".pathChanged() ||
               "ui-distributed-tracing".pathChanged())
   creationTimestamp: null

--- a/.tekton/distributed-tracing-console-plugin-1-4-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/distributed-tracing-console-plugin-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/distributed-tracing-console-plugin-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-distributed-tracing".pathChanged() ||
               "ui-distributed-tracing".pathChanged())

--- a/.tekton/distributed-tracing-console-plugin-pf4-1-4-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf4-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/distributed-tracing-console-plugin-pf4-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/distributed-tracing-console-plugin-pf4-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-distributed-tracing-pf4".pathChanged() ||
               "ui-distributed-tracing-pf4".pathChanged())
   creationTimestamp: null

--- a/.tekton/distributed-tracing-console-plugin-pf4-1-4-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf4-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/distributed-tracing-console-plugin-pf4-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/distributed-tracing-console-plugin-pf4-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-distributed-tracing-pf4".pathChanged() ||
               "ui-distributed-tracing-pf4".pathChanged())

--- a/.tekton/distributed-tracing-console-plugin-pf5-1-4-pull-request.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf5-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/distributed-tracing-console-plugin-pf5-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/distributed-tracing-console-plugin-pf5-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-distributed-tracing-pf5".pathChanged() ||
               "ui-distributed-tracing-pf5".pathChanged())
   creationTimestamp: null

--- a/.tekton/distributed-tracing-console-plugin-pf5-1-4-push.yaml
+++ b/.tekton/distributed-tracing-console-plugin-pf5-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/distributed-tracing-console-plugin-pf5-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/distributed-tracing-console-plugin-pf5-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-distributed-tracing-pf5".pathChanged() ||
               "ui-distributed-tracing-pf5".pathChanged())

--- a/.tekton/korrel8r-1-4-pull-request.yaml
+++ b/.tekton/korrel8r-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/korrel8r-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/korrel8r-1-4-push.yaml".pathChanged() ||
               "Dockerfile.korrel8r".pathChanged() ||
               "korrel8r".pathChanged())
   creationTimestamp: null

--- a/.tekton/korrel8r-1-4-push.yaml
+++ b/.tekton/korrel8r-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/korrel8r-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/korrel8r-1-4-push.yaml".pathChanged() ||
               "Dockerfile.korrel8r".pathChanged() ||
               "korrel8r".pathChanged())

--- a/.tekton/logging-console-plugin-1-4-pull-request.yaml
+++ b/.tekton/logging-console-plugin-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/logging-console-plugin-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/logging-console-plugin-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-logging".pathChanged() ||
               "ui-logging".pathChanged())
   creationTimestamp: null

--- a/.tekton/logging-console-plugin-1-4-push.yaml
+++ b/.tekton/logging-console-plugin-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/logging-console-plugin-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/logging-console-plugin-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-logging".pathChanged() ||
               "ui-logging".pathChanged())

--- a/.tekton/logging-console-plugin-pf4-1-4-pull-request.yaml
+++ b/.tekton/logging-console-plugin-pf4-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/logging-console-plugin-pf4-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/logging-console-plugin-pf4-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-logging-pf4".pathChanged() ||
               "ui-logging-pf4".pathChanged())
   creationTimestamp: null

--- a/.tekton/logging-console-plugin-pf4-1-4-push.yaml
+++ b/.tekton/logging-console-plugin-pf4-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/logging-console-plugin-pf4-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/logging-console-plugin-pf4-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-logging-pf4".pathChanged() ||
               "ui-logging-pf4".pathChanged())

--- a/.tekton/monitoring-console-plugin-1-4-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/monitoring-console-plugin-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/monitoring-console-plugin-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-monitoring".pathChanged() ||
               "ui-monitoring".pathChanged())
   creationTimestamp: null

--- a/.tekton/monitoring-console-plugin-1-4-push.yaml
+++ b/.tekton/monitoring-console-plugin-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/monitoring-console-plugin-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/monitoring-console-plugin-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-monitoring".pathChanged() ||
               "ui-monitoring".pathChanged())

--- a/.tekton/monitoring-console-plugin-pf5-1-4-pull-request.yaml
+++ b/.tekton/monitoring-console-plugin-pf5-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/monitoring-console-plugin-pf5-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/monitoring-console-plugin-pf5-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-monitoring-pf5".pathChanged() ||
               "ui-monitoring-pf5".pathChanged())
   creationTimestamp: null

--- a/.tekton/monitoring-console-plugin-pf5-1-4-push.yaml
+++ b/.tekton/monitoring-console-plugin-pf5-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/monitoring-console-plugin-pf5-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/monitoring-console-plugin-pf5-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-monitoring-pf5".pathChanged() ||
               "ui-monitoring-pf5".pathChanged())

--- a/.tekton/obo-prometheus-operator-1-4-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/obo-prometheus-operator-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/obo-prometheus-operator-1-4-push.yaml".pathChanged() ||
               "Dockerfile.prom-op".pathChanged() ||
               "obo-prometheus-operator".pathChanged())
   creationTimestamp: null

--- a/.tekton/obo-prometheus-operator-1-4-push.yaml
+++ b/.tekton/obo-prometheus-operator-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/obo-prometheus-operator-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/obo-prometheus-operator-1-4-push.yaml".pathChanged() ||
               "Dockerfile.prom-op".pathChanged() ||
               "obo-prometheus-operator".pathChanged())

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-4-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/obo-prometheus-operator-admission-webhook-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/obo-prometheus-operator-admission-webhook-1-4-push.yaml".pathChanged() ||
               "Dockerfile.p-o-admission-webhook".pathChanged() ||
               "obo-prometheus-operator".pathChanged())
   creationTimestamp: null

--- a/.tekton/obo-prometheus-operator-admission-webhook-1-4-push.yaml
+++ b/.tekton/obo-prometheus-operator-admission-webhook-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/obo-prometheus-operator-admission-webhook-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/obo-prometheus-operator-admission-webhook-1-4-push.yaml".pathChanged() ||
               "Dockerfile.p-o-admission-webhook".pathChanged() ||
               "obo-prometheus-operator".pathChanged())

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-pull-request.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-push.yaml".pathChanged() ||
               "Dockerfile.prometheus-config-reloader".pathChanged() ||
               "obo-prometheus-operator".pathChanged())
   creationTimestamp: null

--- a/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-push.yaml
+++ b/.tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/obo-prometheus-operator-prometheus-config-reloader-1-4-push.yaml".pathChanged() ||
               "Dockerfile.prometheus-config-reloader".pathChanged() ||
               "obo-prometheus-operator".pathChanged())

--- a/.tekton/perses-1-4-pull-request.yaml
+++ b/.tekton/perses-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/perses-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/perses-1-4-push.yaml".pathChanged() ||
               "Dockerfile.perses".pathChanged() ||
               "perses".pathChanged())
   creationTimestamp: null

--- a/.tekton/perses-1-4-push.yaml
+++ b/.tekton/perses-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/perses-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/perses-1-4-push.yaml".pathChanged() ||
               "Dockerfile.perses".pathChanged() ||
               "perses".pathChanged())

--- a/.tekton/perses-operator-1-4-pull-request.yaml
+++ b/.tekton/perses-operator-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/perses-operator-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/perses-operator-1-4-push.yaml".pathChanged() ||
               "Dockerfile.perses-operator".pathChanged() ||
               "perses-operator".pathChanged())
   creationTimestamp: null

--- a/.tekton/perses-operator-1-4-push.yaml
+++ b/.tekton/perses-operator-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/perses-operator-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/perses-operator-1-4-push.yaml".pathChanged() ||
               "Dockerfile.perses-operator".pathChanged() ||
               "perses-operator".pathChanged())

--- a/.tekton/prometheus-1-4-pull-request.yaml
+++ b/.tekton/prometheus-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/prometheus-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/prometheus-1-4-push.yaml".pathChanged() ||
               "Dockerfile.prometheus".pathChanged() ||
               "prometheus".pathChanged())
   creationTimestamp: null

--- a/.tekton/prometheus-1-4-push.yaml
+++ b/.tekton/prometheus-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/prometheus-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/prometheus-1-4-push.yaml".pathChanged() ||
               "Dockerfile.prometheus".pathChanged() ||
               "prometheus".pathChanged())

--- a/.tekton/thanos-1-4-pull-request.yaml
+++ b/.tekton/thanos-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/thanos-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/thanos-1-4-push.yaml".pathChanged() ||
               "Dockerfile.thanos".pathChanged() ||
               "thanos".pathChanged())
   creationTimestamp: null

--- a/.tekton/thanos-1-4-push.yaml
+++ b/.tekton/thanos-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/thanos-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/thanos-1-4-push.yaml".pathChanged() ||
               "Dockerfile.thanos".pathChanged() ||
               "thanos".pathChanged())

--- a/.tekton/troubleshooting-panel-console-plugin-1-4-pull-request.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-1-4-pull-request.yaml
@@ -9,10 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |-
-      ((event == "pull_request" && target_branch == "release-1.4") ||
-              (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
+      (event == "pull_request" && target_branch == "release-1.4") &&
               (".tekton/troubleshooting-panel-console-plugin-1-4-pull-request.yaml".pathChanged() ||
-              ".tekton/troubleshooting-panel-console-plugin-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-troubleshooting-panel".pathChanged() ||
               "ui-troubleshooting-panel".pathChanged())
   creationTimestamp: null

--- a/.tekton/troubleshooting-panel-console-plugin-1-4-push.yaml
+++ b/.tekton/troubleshooting-panel-console-plugin-1-4-push.yaml
@@ -10,7 +10,6 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |-
       ((event == "push" && target_branch == "release-1.4") ||
               (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))) &&
-              (".tekton/troubleshooting-panel-console-plugin-1-4-pull-request.yaml".pathChanged() ||
               ".tekton/troubleshooting-panel-console-plugin-1-4-push.yaml".pathChanged() ||
               "Dockerfile.ui-troubleshooting-panel".pathChanged() ||
               "ui-troubleshooting-panel".pathChanged())

--- a/hack/customize-pipeline.sh
+++ b/hack/customize-pipeline.sh
@@ -75,26 +75,36 @@ do
     dockerfile=$(yq '.spec.params[] | select(.name == "dockerfile").value' "$file")
     src="$(grep COPY "$dockerfile" | head -n1 | awk '{print $2}'| cut -d'/' -f1)"
     if [[ "$component" == *"bundle"* ]]; then
-        export trigger="((event == \"$action\" && target_branch == \"$branch\") ||
+        if [[ $action == "push" ]]; then
+            yq -i '.metadata.annotations += {"build.appstudio.openshift.io/build-nudge-files": "hack/update-catalog.sh"}' "$file"
+            yq -i 'with(.spec.params; select(all_c(.name != "build-args")) | . += [{"name": "build-args", "value": ["REGISTRY=registry.redhat.io"]}])' "$file"
+            export trigger="((event == \"$action\" && target_branch == \"$branch\") ||
         (event == \"push\" && target_branch.startsWith(\"gh-readonly-queue/main/\"))) &&
-        (\".tekton/$component-pull-request.yaml\".pathChanged() ||
         \".tekton/$component-push.yaml\".pathChanged() ||
         \"$dockerfile\".pathChanged() ||
         \"bundle-patches/***\".pathChanged() ||
         \"observability-operator/bundle/***\".pathChanged())"
-        if [[ $action == "push" ]]; then
-            yq -i '.metadata.annotations += {"build.appstudio.openshift.io/build-nudge-files": "hack/update-catalog.sh"}' "$file"
-            yq -i 'with(.spec.params; select(all_c(.name != "build-args")) | . += [{"name": "build-args", "value": ["REGISTRY=registry.redhat.io"]}])' "$file"
+        elif  [[ $action == "pull_request" ]]; then
+            export trigger="(event == \"$action\" && target_branch == \"$branch\") &&
+        (\".tekton/$component-pull-request.yaml\".pathChanged() ||
+        \"$dockerfile\".pathChanged() ||
+        \"bundle-patches/***\".pathChanged() ||
+        \"observability-operator/bundle/***\".pathChanged())"
+
         fi
     else
-        export trigger="((event == \"$action\" && target_branch == \"$branch\") ||
+        if [[ $action == "push" ]]; then
+            yq -i '.metadata.annotations += {"build.appstudio.openshift.io/build-nudge-files": "bundle-patches/render_templates"}' "$file"
+            export trigger="((event == \"$action\" && target_branch == \"$branch\") ||
         (event == \"push\" && target_branch.startsWith(\"gh-readonly-queue/main/\"))) &&
-        (\".tekton/$component-pull-request.yaml\".pathChanged() ||
         \".tekton/$component-push.yaml\".pathChanged() ||
         \"$dockerfile\".pathChanged() ||
         \"$src\".pathChanged())"
-        if [[ $action == "push" ]]; then
-            yq -i '.metadata.annotations += {"build.appstudio.openshift.io/build-nudge-files": "bundle-patches/render_templates"}' "$file"
+        elif  [[ $action == "pull_request" ]]; then
+            export trigger="(event == \"$action\" && target_branch == \"$branch\") &&
+        (\".tekton/$component-pull-request.yaml\".pathChanged() ||
+        \"$dockerfile\".pathChanged() ||
+        \"$src\".pathChanged())"
         fi
 
         add_submodule_tasks "$file"

--- a/hack/process_konflux_prs.sh
+++ b/hack/process_konflux_prs.sh
@@ -345,7 +345,7 @@ while IFS= read -r pr_json; do
             if [[ "$VERBOSE" == true ]]; then
                 echo "  Action: Merging PR"
             fi
-            gh pr merge "$pr" --repo "$REPO" --squash --delete-branch
+            gh pr merge "$pr" --repo "$REPO" --squash
         fi
     else
         action="Wait"


### PR DESCRIPTION
Only trigger push pipelines for merge queue merges. This change also allows us to be more selective for triggering on pipeline file changes (push only gets triggered by changes to the push definitions now).