### PR TITLE
fix(ci): revert buildah-task to latest digest and use sha256 pinning

### DIFF
--- a/.tekton/tasks/get-submodule-commit-labels.yaml
+++ b/.tekton/tasks/get-submodule-commit-labels.yaml
@@ -27,7 +27,7 @@ spec:
         - use
         - $(params.SOURCE-ARTIFACT)=/tekton/home/source
     - name: get-submodule-sha
-      image: quay.io/konflux-ci/buildah-task:4d8273444b0f2781264c232e12e88449bbf078c99e3da2a7f6dcaaf27bc53712
+      image: quay.io/konflux-ci/buildah-task@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
       workingDir: /tekton/home/source
       script: |
         #!/bin/bash

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
     "extends": [
-        "github>konflux-ci/mintmaker//config/renovate/renovate.json",
         "github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles"
     ],
     "ignoreDeps": [


### PR DESCRIPTION
Renovate misinterpreted the buildah-task manifest list digest as a
semver tag, downgrading to an older image which lacks git.

Switch to @sha256: digest pinning to prevent future misinterpretation
and remove the global mintmaker extends from renovate.json.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>