### PR TITLE
fix: inject version info via ldflags into prometheus and alertmanager…

### DIFF
--- a/.tekton/alertmanager-1-5-pull-request.yaml
+++ b/.tekton/alertmanager-1-5-pull-request.yaml
@@ -235,6 +235,9 @@ spec:
           - name: BUILD_ARGS
             value:
               - $(params.build-args[*])
+              - REVISION=$(tasks.get-submodule-commit-labels.results.revision)
+              - BRANCH=$(tasks.get-submodule-commit-labels.results.branch)
+              - VERSION=$(tasks.get-submodule-commit-labels.results.version)
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
           - name: PRIVILEGED_NESTED

--- a/.tekton/alertmanager-1-5-pull-request.yaml
+++ b/.tekton/alertmanager-1-5-pull-request.yaml
@@ -235,9 +235,9 @@ spec:
           - name: BUILD_ARGS
             value:
               - $(params.build-args[*])
-              - REVISION=$(tasks.get-submodule-commit-labels.results.revision)
-              - BRANCH=$(tasks.get-submodule-commit-labels.results.branch)
-              - VERSION=$(tasks.get-submodule-commit-labels.results.version)
+              - GIT_REVISION=$(tasks.get-submodule-commit-labels.results.revision)
+              - GIT_BRANCH=$(tasks.get-submodule-commit-labels.results.branch)
+              - GIT_VERSION=$(tasks.get-submodule-commit-labels.results.version)
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
           - name: PRIVILEGED_NESTED

--- a/.tekton/alertmanager-1-5-push.yaml
+++ b/.tekton/alertmanager-1-5-push.yaml
@@ -233,6 +233,9 @@ spec:
           - name: BUILD_ARGS
             value:
               - $(params.build-args[*])
+              - REVISION=$(tasks.get-submodule-commit-labels.results.revision)
+              - BRANCH=$(tasks.get-submodule-commit-labels.results.branch)
+              - VERSION=$(tasks.get-submodule-commit-labels.results.version)
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
           - name: PRIVILEGED_NESTED

--- a/.tekton/alertmanager-1-5-push.yaml
+++ b/.tekton/alertmanager-1-5-push.yaml
@@ -233,9 +233,9 @@ spec:
           - name: BUILD_ARGS
             value:
               - $(params.build-args[*])
-              - REVISION=$(tasks.get-submodule-commit-labels.results.revision)
-              - BRANCH=$(tasks.get-submodule-commit-labels.results.branch)
-              - VERSION=$(tasks.get-submodule-commit-labels.results.version)
+              - GIT_REVISION=$(tasks.get-submodule-commit-labels.results.revision)
+              - GIT_BRANCH=$(tasks.get-submodule-commit-labels.results.branch)
+              - GIT_VERSION=$(tasks.get-submodule-commit-labels.results.version)
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
           - name: PRIVILEGED_NESTED

--- a/.tekton/prometheus-1-5-pull-request.yaml
+++ b/.tekton/prometheus-1-5-pull-request.yaml
@@ -248,6 +248,9 @@ spec:
           - name: BUILD_ARGS
             value:
               - $(params.build-args[*])
+              - REVISION=$(tasks.get-submodule-commit-labels.results.revision)
+              - BRANCH=$(tasks.get-submodule-commit-labels.results.branch)
+              - VERSION=$(tasks.get-submodule-commit-labels.results.version)
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
           - name: PRIVILEGED_NESTED

--- a/.tekton/prometheus-1-5-pull-request.yaml
+++ b/.tekton/prometheus-1-5-pull-request.yaml
@@ -248,9 +248,9 @@ spec:
           - name: BUILD_ARGS
             value:
               - $(params.build-args[*])
-              - REVISION=$(tasks.get-submodule-commit-labels.results.revision)
-              - BRANCH=$(tasks.get-submodule-commit-labels.results.branch)
-              - VERSION=$(tasks.get-submodule-commit-labels.results.version)
+              - GIT_REVISION=$(tasks.get-submodule-commit-labels.results.revision)
+              - GIT_BRANCH=$(tasks.get-submodule-commit-labels.results.branch)
+              - GIT_VERSION=$(tasks.get-submodule-commit-labels.results.version)
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
           - name: PRIVILEGED_NESTED

--- a/.tekton/prometheus-1-5-push.yaml
+++ b/.tekton/prometheus-1-5-push.yaml
@@ -246,6 +246,9 @@ spec:
           - name: BUILD_ARGS
             value:
               - $(params.build-args[*])
+              - REVISION=$(tasks.get-submodule-commit-labels.results.revision)
+              - BRANCH=$(tasks.get-submodule-commit-labels.results.branch)
+              - VERSION=$(tasks.get-submodule-commit-labels.results.version)
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
           - name: PRIVILEGED_NESTED

--- a/.tekton/prometheus-1-5-push.yaml
+++ b/.tekton/prometheus-1-5-push.yaml
@@ -246,9 +246,9 @@ spec:
           - name: BUILD_ARGS
             value:
               - $(params.build-args[*])
-              - REVISION=$(tasks.get-submodule-commit-labels.results.revision)
-              - BRANCH=$(tasks.get-submodule-commit-labels.results.branch)
-              - VERSION=$(tasks.get-submodule-commit-labels.results.version)
+              - GIT_REVISION=$(tasks.get-submodule-commit-labels.results.revision)
+              - GIT_BRANCH=$(tasks.get-submodule-commit-labels.results.branch)
+              - GIT_VERSION=$(tasks.get-submodule-commit-labels.results.version)
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
           - name: PRIVILEGED_NESTED

--- a/.tekton/tasks/get-submodule-commit-labels.yaml
+++ b/.tekton/tasks/get-submodule-commit-labels.yaml
@@ -61,7 +61,7 @@ spec:
 
         # Get branch and version info
         submodule_branch=$(git rev-parse --abbrev-ref HEAD)
-        submodule_version=$(cat VERSION)
+        submodule_version=$(cat ./VERSION)
 
         # Write results
         echo "$submodule_commit_url"

--- a/.tekton/tasks/get-submodule-commit-labels.yaml
+++ b/.tekton/tasks/get-submodule-commit-labels.yaml
@@ -20,6 +20,15 @@ spec:
     - name: labels
       type: array
       description: LABELS array for buildah
+    - name: revision
+      type: string
+      description: The submodule commit SHA.
+    - name: branch
+      type: string
+      description: The submodule branch name.
+    - name: version
+      type: string
+      description: The submodule version derived from git describe.
   steps:
     - name: use-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:fe8e5c96d66b9b72ed8adeebecf9121c57ca198a9331983ca985670a2ef55647
@@ -50,8 +59,15 @@ spec:
         submodule_url=$(git remote get-url origin)
         submodule_commit_url=${submodule_url%.git}/commit/${submodule_sha}
 
+        # Get branch and version info
+        submodule_branch=$(git rev-parse --abbrev-ref HEAD)
+        submodule_version=$(cat VERSION)
+
         # Write results
         echo "$submodule_commit_url"
         printf '["commit.id=%s", "commit.url=%s"]' "${submodule_sha}" "${submodule_commit_url}" > $(results.labels.path)
+        printf '%s' "${submodule_sha}" > $(results.revision.path)
+        printf '%s' "${submodule_branch}" > $(results.branch.path)
+        printf '%s' "${submodule_version}" > $(results.version.path)
 
         echo -e "\nSubmodule commit SHAs extracted successfully"

--- a/Dockerfile.alertmanager
+++ b/Dockerfile.alertmanager
@@ -4,14 +4,22 @@ WORKDIR /workspace
 
 COPY alertmanager/ .
 
+ARG VERSION=
+ARG REVISION=unknown
+ARG BRANCH=
+
 ENV GOFLAGS='-mod=mod -tags=netgo'
 ENV GOTOOLCHAIN=local
 ENV CGO_ENABLED=1
 ENV GOEXPERIMENT=strictfipsruntime
 ENV NO_DOCKER=true
 
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -o alertmanager github.com/prometheus/alertmanager/cmd/alertmanager
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -o amtool github.com/prometheus/alertmanager/cmd/amtool
+RUN GOLDFLAGS="-X github.com/prometheus/common/version.Version=${VERSION} \
+    -X github.com/prometheus/common/version.Revision=${REVISION} \
+    -X github.com/prometheus/common/version.Branch=${BRANCH} \
+    -X github.com/prometheus/common/version.BuildDate=$(date -u +%Y%m%d-%H:%M:%S)" && \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -ldflags="$GOLDFLAGS" -o alertmanager github.com/prometheus/alertmanager/cmd/alertmanager && \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -ldflags="$GOLDFLAGS" -o amtool github.com/prometheus/alertmanager/cmd/amtool
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:fe9e574f04371b333ed4e21d30d984f6b7fcd1046e579f5ddab4816c0c8e231d
 

--- a/Dockerfile.alertmanager
+++ b/Dockerfile.alertmanager
@@ -4,9 +4,9 @@ WORKDIR /workspace
 
 COPY alertmanager/ .
 
-ARG VERSION=
-ARG REVISION=unknown
-ARG BRANCH=
+ARG GIT_VERSION=
+ARG GIT_REVISION=unknown
+ARG GIT_BRANCH=
 
 ENV GOFLAGS='-mod=mod -tags=netgo'
 ENV GOTOOLCHAIN=local
@@ -14,9 +14,9 @@ ENV CGO_ENABLED=1
 ENV GOEXPERIMENT=strictfipsruntime
 ENV NO_DOCKER=true
 
-RUN GOLDFLAGS="-X github.com/prometheus/common/version.Version=${VERSION} \
-    -X github.com/prometheus/common/version.Revision=${REVISION} \
-    -X github.com/prometheus/common/version.Branch=${BRANCH} \
+RUN GOLDFLAGS="-X github.com/prometheus/common/version.Version=${GIT_VERSION} \
+    -X github.com/prometheus/common/version.Revision=${GIT_REVISION} \
+    -X github.com/prometheus/common/version.Branch=${GIT_BRANCH} \
     -X github.com/prometheus/common/version.BuildDate=$(date -u +%Y%m%d-%H:%M:%S)" && \
     GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -ldflags="$GOLDFLAGS" -o alertmanager github.com/prometheus/alertmanager/cmd/alertmanager && \
     GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -ldflags="$GOLDFLAGS" -o amtool github.com/prometheus/alertmanager/cmd/amtool
@@ -39,12 +39,11 @@ ENTRYPOINT [ "/bin/alertmanager" ]
 CMD        [ "--config.file=/etc/alertmanager/alertmanager.yml", \
     "--storage.path=/alertmanager" ]
 
-ARG VERSION=v0.31.0
 LABEL com.redhat.component="coo-alertmanager" \
     name="cluster-observability-operator/alertmanager-rhel9" \
     cpe="cpe:/a:redhat:cluster_observability_operator:1.5::el9" \
-    version="${VERSION}" \
-    release="${VERSION}" \
+    version="${GIT_VERSION}" \
+    release="${GIT_VERSION}" \
     vendor="Red Hat, Inc." \
     distribution-scope="public" \
     url="https://github.com/prometheus/alertmanager" \

--- a/Dockerfile.prometheus
+++ b/Dockerfile.prometheus
@@ -16,18 +16,18 @@ WORKDIR /workspace
 
 COPY --from=web-builder /workspace/ .
 
-ARG VERSION=
-ARG REVISION=unknown
-ARG BRANCH=
+ARG GIT_VERSION=
+ARG GIT_REVISION=unknown
+ARG GIT_BRANCH=
 
 ENV GOFLAGS='-mod=mod -tags=builtinassets,netgo,stringlabels'
 ENV GOTOOLCHAIN=local
 ENV CGO_ENABLED=1
 ENV GOEXPERIMENT=strictfipsruntime
 
-RUN GOLDFLAGS="-X github.com/prometheus/common/version.Version=${VERSION} \
-    -X github.com/prometheus/common/version.Revision=${REVISION} \
-    -X github.com/prometheus/common/version.Branch=${BRANCH} \
+RUN GOLDFLAGS="-X github.com/prometheus/common/version.Version=${GIT_VERSION} \
+    -X github.com/prometheus/common/version.Revision=${GIT_REVISION} \
+    -X github.com/prometheus/common/version.Branch=${GIT_BRANCH} \
     -X github.com/prometheus/common/version.BuildDate=$(date -u +%Y%m%d-%H:%M:%S)" && \
     GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -ldflags="$GOLDFLAGS" -o ./prometheus ./cmd/prometheus && \
     GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -ldflags="$GOLDFLAGS" -o ./promtool ./cmd/promtool
@@ -52,12 +52,11 @@ ENTRYPOINT ["/bin/prometheus"]
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
     "--storage.tsdb.path=/prometheus" ]
 
-ARG VERSION=v3.9.1
 LABEL com.redhat.component="coo-prometheus-container" \
     name="cluster-observability-operator/prometheus-rhel9" \
     cpe="cpe:/a:redhat:cluster_observability_operator:1.5::el9" \
-    version="${VERSION}" \
-    release="${VERSION}" \
+    version="${GIT_VERSION}" \
+    release="${GIT_VERSION}" \
     vendor="Red Hat, Inc." \
     distribution-scope="public" \
     url="https://github.com/prometheus/prometheus" \

--- a/Dockerfile.prometheus
+++ b/Dockerfile.prometheus
@@ -16,13 +16,21 @@ WORKDIR /workspace
 
 COPY --from=web-builder /workspace/ .
 
+ARG VERSION=
+ARG REVISION=unknown
+ARG BRANCH=
+
 ENV GOFLAGS='-mod=mod -tags=builtinassets,netgo,stringlabels'
 ENV GOTOOLCHAIN=local
 ENV CGO_ENABLED=1
 ENV GOEXPERIMENT=strictfipsruntime
-# Build prometheus directly using Go
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -o ./prometheus ./cmd/prometheus
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -o ./promtool ./cmd/promtool
+
+RUN GOLDFLAGS="-X github.com/prometheus/common/version.Version=${VERSION} \
+    -X github.com/prometheus/common/version.Revision=${REVISION} \
+    -X github.com/prometheus/common/version.Branch=${BRANCH} \
+    -X github.com/prometheus/common/version.BuildDate=$(date -u +%Y%m%d-%H:%M:%S)" && \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -ldflags="$GOLDFLAGS" -o ./prometheus ./cmd/prometheus && \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GOFLAGS -ldflags="$GOLDFLAGS" -o ./promtool ./cmd/promtool
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:fe9e574f04371b333ed4e21d30d984f6b7fcd1046e579f5ddab4816c0c8e231d
 


### PR DESCRIPTION
… builds

The prometheus and alertmanager binaries were built with plain go build, resulting in empty version/branch and unknown revision at startup.

Extend the get-submodule-commit-labels task to extract revision, branch, and version from the submodule git state. Pass these as build args to the Dockerfiles which now use them as -ldflags to set the github.com/prometheus/common/version variables.

Fixes: COO-1329