### PR TITLE
fix: add NetworkPolicy RBAC to CSV for Conforma OCP 5.0 compliance

### DIFF
--- a/bundle-patches/render_templates
+++ b/bundle-patches/render_templates
@@ -34,6 +34,11 @@ yq -i '.metadata.labels += {"operatorframework.io/arch.arm64": "supported"}' "$c
 yq -i '.metadata.labels += {"operatorframework.io/arch.ppc64le": "supported"}' "$csv_file"
 yq -i '.metadata.labels += {"operatorframework.io/arch.s390x": "supported"}' "$csv_file"
 
+# Add NetworkPolicy RBAC for Conforma policy: olm.required_network_policy_rbac_for_operands
+# Required for OCP 5.0 compliance. Conforma checks the CSV declares RBAC for
+# networking.k8s.io/networkpolicies with create, delete, and patch.
+yq -i '(.spec.install.spec.clusterPermissions[0].rules) += [{"apiGroups": ["networking.k8s.io"], "resources": ["networkpolicies"], "verbs": ["create", "delete", "patch"]}]' "$csv_file"
+
 # Konflux Build Pipeline should automatically create PRs to update the SHA images but no always
 # Use 'update-component-images.sh' to update the render_templates file with the latest SHA images
 COO_IMAGE_URL="quay.io/redhat-user-workloads/cluster-observabilit-tenant/cluster-observability-operator/cluster-observability-rhel9-operator@sha256:f2807442f7f48939a97f2bfbcaef51a0a87523347336d9d8689d185863530045"


### PR DESCRIPTION
Add networking.k8s.io/networkpolicies RBAC permissions (create, delete,
 patch) to the bundle CSV via render_templates.

This satisfies the Conforma policy
olm.required_network_policy_rbac_for_operands, which becomes a release
blocker on August 8, 2026.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>
