### PR TITLE
fix(thanos): add missing slicelabels build tag

### DIFF
--- a/Dockerfile.thanos
+++ b/Dockerfile.thanos
@@ -13,7 +13,7 @@ ENV GOEXPERIMENT=strictfipsruntime
 # prefetch cache (…/pkg/mod/cache/download/*.zip) that Thanos builds hit as missing. The submodule
 # ships vendor/; -mod=vendor avoids that. Pass -mod/-tags on the CLI so they override GOFLAGS.
 ARG TARGETOS TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -mod=vendor -tags=netgo -o /go/bin/thanos ./cmd/thanos
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -mod=vendor -tags=netgo,slicelabels -o /go/bin/thanos ./cmd/thanos
 
 FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:ae09ecc3d754bc1726cbda3e2599cc7839e09fe1cc547ce173cf669b645be3cc
 WORKDIR /


### PR DESCRIPTION
The thanos build was missing the required slicelabels build tag, causing the thanos-sidecar to panic with "makeslice: len out of range" on every gRPC request. This is because thanos has unsafe code that assumes labels.Labels uses the slice representation.

The upstream .promu.yml and Dockerfile.ocp both include this tag.

Ref: https://github.com/thanos-io/thanos/issues/8543
Ref: https://redhat.atlassian.net/browse/COO-1851