### PR TITLE
Update Alertmanager to obo fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "alertmanager"]
 	path = alertmanager
-	url = https://github.com/prometheus/alertmanager
+	url = https://github.com/rhobs/obo-alertmanager
 	# make sure to update the web assets fetched in artifacts.lock.yaml to match
-	branch = v0.32.1 # git submodules can't handle tags, but renovate can
+	branch = v0.32.2 # git submodules can't handle tags, but renovate can
 [submodule "prometheus"]
 	path = prometheus
 	url = https://github.com/prometheus/prometheus.git

--- a/alertmanager-artifacts.lock.yaml
+++ b/alertmanager-artifacts.lock.yaml
@@ -1,6 +1,6 @@
 metadata:
   version: "1.0"
 artifacts:
-  - download_url: "https://github.com/prometheus/alertmanager/releases/download/v0.32.1/alertmanager-web-ui-0.32.1.tar.gz"
-    checksum: "sha256:fca5b665281e603c055d812ac0359b027772c5e30c9a8cd0ca1367aac698cfa6"
+  - download_url: "https://github.com/prometheus/alertmanager/releases/download/v0.32.2/alertmanager-web-ui-0.32.2.tar.gz"
+    checksum: "sha256:d5e399f7facce0d7d1f97c16a2fa387d4182f9b30a41ade79df6b7d867d8f4fb"
     filename: "alertmanager-web-ui.tar.gz"


### PR DESCRIPTION
This commit updates the Alertmanager submodule to point to the https://github.com/rhobs/obo-alertmanager fork which carries CVE fixes for `golang.org/x/net` and `golang.org/x/crypto`.

Ideally we would use the
https://github.com/openshift/prometheus-alertmanager but there's no branch matching the v0.32.x release.