### PR TITLE
COO-2082: embed timezone information in binaries

### DIFF
--- a/Dockerfile.alertmanager
+++ b/Dockerfile.alertmanager
@@ -10,7 +10,7 @@ ARG GIT_VERSION=
 ARG GIT_REVISION=unknown
 ARG GIT_BRANCH=
 
-ENV GOFLAGS='-mod=readonly -tags=netgo'
+ENV GOFLAGS='-mod=readonly -tags=netgo,timetzdata'
 ENV GOTOOLCHAIN=local
 ENV CGO_ENABLED=1
 ENV GOEXPERIMENT=strictfipsruntime

--- a/Dockerfile.p-o-admission-webhook
+++ b/Dockerfile.p-o-admission-webhook
@@ -4,7 +4,7 @@ WORKDIR /workspace
 # Copy source files
 COPY obo-prometheus-operator/ .
 
-ENV GOFLAGS='-mod=readonly'
+ENV GOFLAGS='-mod=readonly -tags=timetzdata'
 ENV GOTOOLCHAIN=local
 ENV CGO_ENABLED=1
 ENV GOEXPERIMENT=strictfipsruntime

--- a/Dockerfile.prom-op
+++ b/Dockerfile.prom-op
@@ -4,7 +4,7 @@ WORKDIR /workspace
 # Copy source files
 COPY obo-prometheus-operator/ .
 
-ENV GOFLAGS='-mod=mod'
+ENV GOFLAGS='-mod=readonly -tags=timetzdata'
 
 ENV GOTOOLCHAIN=local
 ENV CGO_ENABLED=1

--- a/Dockerfile.prometheus-config-reloader
+++ b/Dockerfile.prometheus-config-reloader
@@ -4,7 +4,7 @@ WORKDIR /workspace
 # Copy source files
 COPY obo-prometheus-operator/ .
 
-ENV GOFLAGS='-mod=readonly'
+ENV GOFLAGS='-mod=readonly -tags=timetzdata'
 ENV CGO_ENABLED=1
 ENV GOEXPERIMENT=strictfipsruntime
 


### PR DESCRIPTION
This commit updates the Go build command to embed the toolchain's timezone information into the Alertmanager, Prometheus operator, config reloader and admission webhook binaries because the UBI minimal images lack `/usr/share/zoneinfo`.

Though it's not strictly needed for the last two components, the information may be required in the future.